### PR TITLE
fix: restore THREE import to resolve hero blank screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Play, Square, Mail, Phone, MapPin, ChevronLeft, ChevronRight } from "lucide-react";
+import * as THREE from "three";
 
 
 const pub = (p) => `${import.meta.env.BASE_URL}${p.replace(/^\/+/, '')}`;


### PR DESCRIPTION
## Summary
- restore `three` import in App component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa8a611008832bb9b02cdfe6541ac3