### PR TITLE
Improve hero image loading priority

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -792,7 +792,7 @@ const ProjectCard = ({ project }) => {
       style={{ objectFit: 'contain', objectPosition: 'center' }}
       loading="lazy"
       decoding="async"
-      fetchpriority="low"
+        fetchpriority="high"
       sizes="(min-width: 1024px) 66vw, 100vw"
       onLoad={(e) => {
         const w = e.target.naturalWidth || 16;


### PR DESCRIPTION
## Summary
- Increase hero image fetch priority to speed up initial load

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab81e20d6c832b9ce92b4246662ffc