### PR TITLE
Enhance image fades and add SEO/analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,15 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-0ZG2421NPF"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-0ZG2421NPF');
+    </script>
     <meta charset="UTF-8" />
     <meta
       name="viewport"
@@ -12,6 +21,17 @@
     <meta name="description" content=" Lighting and projection designer based in New York, specializing in theatre, concerts, and live events. View portfolio and contact Henry here.">
     <meta name="keywords" content="lighting designer, projection designer, theatre, concerts, live events, New York, portfolio">
     <meta name="author" content="Henry Kacik" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://henrykacik.com/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Henry Kacik — Lighting & Projection Designer" />
+    <meta property="og:description" content="Lighting and projection designer based in New York, specializing in theatre, concerts, and live events. View portfolio and contact Henry here." />
+    <meta property="og:url" content="https://henrykacik.com/" />
+    <meta property="og:image" content="/Henry%20Kacik.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Henry Kacik — Lighting & Projection Designer" />
+    <meta name="twitter:description" content="Lighting and projection designer based in New York, specializing in theatre, concerts, and live events. View portfolio and contact Henry here." />
+    <meta name="twitter:image" content="/Henry%20Kacik.png" />
 
     <!-- Favicon -->
     <link rel="icon" href="/favicon.ico" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -516,7 +516,8 @@ const Hero = ({ onSeeWork, onNavigate }) => {
        />
      </motion.div>
   </AnimatePresence>
- )}
+)}
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_70%,black_100%)]" />
       <div
         className="pointer-events-none absolute inset-0"
         style={{ background: 'radial-gradient(circle at center, transparent 60%, rgba(0,0,0,0.85) 90%, black 100%)' }}
@@ -814,6 +815,7 @@ const ProjectCard = ({ project }) => {
         }}
       />
     )}
+    <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_70%,black_100%)]" />
        <button
           onClick={open}
           className="absolute bottom-6 right-6 border border-white px-4 py-2 text-sm uppercase hover:bg-white hover:text-black transition"
@@ -886,6 +888,7 @@ const Portfolio = () => {
                     />
                   )}
                 </AnimatePresence>
+                <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_70%,black_100%)]" />
               </motion.div>
               <LightboxDetails active={active} idx={idx} />
               <div className="mt-3 flex items-center justify-between text-white/80">
@@ -905,7 +908,7 @@ const About = ({ onNavigate }) => (
     <SectionTitle>About</SectionTitle>
     <div className="mx-auto max-w-5xl grid md:grid-cols-12 gap-8 items-center">
       <div className="md:col-span-5 overflow-hidden rounded-2xl shadow-2xl ring-1 ring-black/5 dark:ring-white/10">
-        <img src={ABOUT.photo} className="w-full h-auto block" loading="eager" decoding="async" fetchpriority="high" sizes="(min-width: 768px) 40vw, 90vw"/>
+        <img src={ABOUT.photo} alt="Headshot of Henry Kacik" className="w-full h-auto block" loading="eager" decoding="async" fetchpriority="high" sizes="(min-width: 768px) 40vw, 90vw"/>
       </div>
       <div className="md:col-span-7">
         <h3 className="text-2xl font-semibold mb-3" style={{ fontFamily: '"Fraunces", serif' }}>{ABOUT.headline}</h3>


### PR DESCRIPTION
## Summary
- Smoothly fade photo edges into the black border with radial gradient overlays
- Insert Google Analytics snippet and expand SEO meta tags
- Add missing alt text for headshot image

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aba0f4ad60832b8a9ff250060dc717