### PR TITLE
Refine meta and gate WebGL effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,17 @@
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://henrykacik.com/" />
 
+  <!--
+    TODO (after images are uploaded to /public):
+     - Replace inline SVG favicon with:
+         <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png">
+         <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16.png">
+         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png">
+     - Point social previews to:
+         <meta property="og:image" content="https://henrykacik.com/og-hero.jpg" />
+         <meta name="twitter:image" content="https://henrykacik.com/og-hero.jpg" />
+  -->
+
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Henry Kacik — Lighting & Projection Designer" />
   <meta property="og:description" content="Lighting and projection designer based in New York, specializing in theatre, concerts, and live events. View portfolio and contact Henry here." />
@@ -40,7 +51,7 @@
 
   <!-- App look-and-feel & basic security -->
   <meta name="theme-color" content="#000000" />
-  <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin" />
+  <meta name="referrer" content="strict-origin-when-cross-origin" />
   <!-- X-Content-Type-Options must be a response header; omit the meta -->
 
   <!-- Favicon -->

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://henrykacik.com/</loc></url>
-  <url><loc>https://henrykacik.com/#about</loc></url>
-  <url><loc>https://henrykacik.com/#portfolio</loc></url>
-  <url><loc>https://henrykacik.com/#resume</loc></url>
-  <url><loc>https://henrykacik.com/#contact</loc></url>
 </urlset>
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -465,7 +465,14 @@ const Nav = ({ route, onNav, lxMode, setLxMode }) => {
   aria-label="Main"
   className="fixed top-0 left-0 z-50 flex w-full justify-between pt-[max(1rem,env(safe-area-inset-top))] pl-[max(1rem,env(safe-area-inset-left))] pr-[max(1rem,env(safe-area-inset-right))]"
 >
-      <span className="text-2xl text-white mix-blend-difference" style={{ fontFamily: 'Fraunces, serif' }}>Henry Kacik</span>
+      <button
+        onClick={() => onNav('home')}
+        aria-label="Go to home"
+        className="text-2xl text-white mix-blend-difference"
+        style={{ fontFamily: 'Fraunces, serif' }}
+      >
+        Henry Kacik
+      </button>
       <div className="flex gap-4 overflow-x-auto whitespace-nowrap">
         {items.map(it => (
           <button
@@ -625,14 +632,19 @@ const ParticleHero = ({ imageUrl, onReady, onError }) => {
 
     (async () => {
       try {
-        // Capability gating
+        // Capability gating (keep it light; avoid importing three unless we pass)
         const prefersReduced = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
         const coarsePointer  = window.matchMedia?.('(pointer: coarse)')?.matches;
         const cores = navigator.hardwareConcurrency || 4;
-        const memoryOK = (navigator.deviceMemory || 4) >= 4;
-        const enableFx = !prefersReduced && !coarsePointer && cores >= 6 && memoryOK;
-        if (!enableFx) { onError?.(); return; }
+        const memoryGB = navigator.deviceMemory || 4;
+        const enableFx = !prefersReduced && !coarsePointer && cores >= 6 && memoryGB >= 4;
 
+        if (!enableFx) {
+          onError?.();
+          return;
+        }
+
+        // Import three ONLY if enabled
         const THREE = await import('three');
         if (cancelled) return;
 


### PR DESCRIPTION
## Summary
- use name-based referrer meta and add TODO for swapping favicon and OG assets
- simplify sitemap to only root URL for SPA
- make brand in nav clickable home button and gate ParticleHero behind capability check

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acff845f50832b8d64e5a9b4aa98dc