### PR TITLE
Add locale and color-scheme meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:image:alt" content="Portrait / branding image for Henry Kacik" />
+  <meta property="og:locale" content="en_US" />
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Henry Kacik — Lighting & Projection Designer" />
@@ -52,6 +53,7 @@
 
   <!-- App look-and-feel & basic security -->
   <meta name="theme-color" content="#000000" />
+  <meta name="color-scheme" content="dark light" />
   <meta name="referrer" content="strict-origin-when-cross-origin" />
   <!-- X-Content-Type-Options must be a response header; omit the meta -->
 


### PR DESCRIPTION
## Summary
- add `og:locale` meta tag to clarify Open Graph locale
- support both dark and light appearance via `color-scheme` meta

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad06751138832bb86e9bf0eab3d2de