### PR TITLE
Update preview images and favicons

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,23 +24,13 @@
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://henrykacik.com/" />
 
-  <!--
-    TODO (after images are uploaded to /public):
-     - Replace inline SVG favicon with:
-         <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png">
-         <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16.png">
-         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png">
-     - Point social previews to:
-         <meta property="og:image" content="https://henrykacik.com/og-hero.jpg" />
-         <meta name="twitter:image" content="https://henrykacik.com/og-hero.jpg" />
-  -->
 
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Henry Kacik — Lighting & Projection Designer" />
   <meta property="og:description" content="Lighting and projection designer based in New York, specializing in theatre, concerts, and live events. View portfolio and contact Henry here." />
   <meta property="og:url" content="https://henrykacik.com/" />
   <meta property="og:site_name" content="Henry Kacik — Lighting & Projection Designer" />
-  <meta property="og:image" content="https://henrykacik.com/Henry%20Kacik.png" />
+  <meta property="og:image" content="https://henrykacik.com/og-hero.jpg" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
   <meta property="og:image:alt" content="Portrait / branding image for Henry Kacik" />
@@ -49,7 +39,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Henry Kacik — Lighting & Projection Designer" />
   <meta name="twitter:description" content="Lighting and projection designer based in New York, specializing in theatre, concerts, and live events. View portfolio and contact Henry here." />
-  <meta name="twitter:image" content="https://henrykacik.com/Henry%20Kacik.png" />
+  <meta name="twitter:image" content="https://henrykacik.com/og-hero.jpg" />
 
   <!-- App look-and-feel & basic security -->
   <meta name="theme-color" content="#000000" />
@@ -58,8 +48,9 @@
   <!-- X-Content-Type-Options must be a response header; omit the meta -->
 
   <!-- Favicon -->
-  <!-- Inline SVG favicon to avoid adding binary files in this PR -->
-  <link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%20viewBox%3D%270%200%2064%2064%27%3E%3Crect%20width%3D%2764%27%20height%3D%2764%27%20rx%3D%278%27%20fill%3D%27black%27%2F%3E%3Ctext%20x%3D%2750%25%27%20y%3D%2750%25%27%20dy%3D%270.1em%27%20text-anchor%3D%27middle%27%20font-family%3D%27Arial%2CHelvetica%2Csans-serif%27%20font-size%3D%2728%27%20fill%3D%27white%27%3EHK%3C%2Ftext%3E%3C%2Fsvg%3E" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/icons/favicon-16.png" />
+  <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
 
   <!-- Structured data -->
   <script type="application/ld+json">
@@ -71,7 +62,7 @@
     "jobTitle": "Lighting & Projection Designer",
     "url": "https://henrykacik.com",
     "email": "mailto:hchkacik@gmail.com",
-    "image": "https://henrykacik.com/Henry%20Kacik.png",
+    "image": "https://henrykacik.com/og-hero.jpg",
     "address": {
       "@type": "PostalAddress",
       "addressLocality": "Brooklyn",


### PR DESCRIPTION
## Summary
- point OG and Twitter preview metadata to the new `og-hero.jpg`
- replace inline SVG favicon with PNG favicon and Apple touch icon links
- align Person JSON-LD image with the new social preview image

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad177151a8832b86c5a2223abc96cd