### PR TITLE
Fix Hildegarde photo paths

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -28,28 +28,28 @@ const ABOUT = {
 const PROJECTS = [
 
  {
-  id: "hildegard-2026",
+  id: "hildegarde-2026",
   title: "Sarah Kirkland Snider's Hildegarde",
   role: "Lighting Designer",
   year: "2026",
-  hero: pub("hildegard/Hildegard15.jpg"),
+  hero: pub("hildegarde/Hildegarde15.jpg"),
   blurb: "Sarah Kirkland Snider’s chamber opera follows Hildegard von Bingen through visions, faith, and the pull between private revelation and public power. For this semi-staged Aspen Music Festival performance, the lighting performed alongside the projections to create Hildegarde's religious visions.",
   photos: [
-    pub("hildegard/Hildegard1.jpg"),
-    pub("hildegard/Hildegard2.jpg"),
-    pub("hildegard/Hildegard3.jpg"),
-    pub("hildegard/Hildegard4.jpg"),
-    pub("hildegard/Hildegard5.jpg"),
-    pub("hildegard/Hildegard6.jpg"),
-    pub("hildegard/Hildegard7.jpg"),
-    pub("hildegard/Hildegard8.jpg"),
-    pub("hildegard/Hildegard9.jpg"),
-    pub("hildegard/Hildegard10.jpg"),
-    pub("hildegard/Hildegard11.jpg"),
-    pub("hildegard/Hildegard12.jpg"),
-    pub("hildegard/Hildegard13.jpg"),
-    pub("hildegard/Hildegard14.jpg"),
-    pub("hildegard/Hildegard15.jpg")
+    pub("hildegarde/Hildegarde1.jpg"),
+    pub("hildegarde/Hildegarde2.jpg"),
+    pub("hildegarde/Hildegarde3.jpg"),
+    pub("hildegarde/Hildegarde4.jpg"),
+    pub("hildegarde/Hildegarde5.jpg"),
+    pub("hildegarde/Hildegarde6.jpg"),
+    pub("hildegarde/Hildegarde7.jpg"),
+    pub("hildegarde/Hildegarde8.jpg"),
+    pub("hildegarde/Hildegarde9.jpg"),
+    pub("hildegarde/Hildegarde10.jpg"),
+    pub("hildegarde/Hildegarde11.jpg"),
+    pub("hildegarde/Hildegarde12.jpg"),
+    pub("hildegarde/Hildegarde13.jpg"),
+    pub("hildegarde/Hildegarde14.jpg"),
+    pub("hildegarde/Hildegarde15.jpg")
     
   ],
   captions: [


### PR DESCRIPTION
### Motivation
- The Hildegarde portfolio images placed in `public/hildegarde` were not appearing because the code referenced the wrong directory/name (`hildegard`) and used a mismatched project id.

### Description
- Update `src/App.jsx` to use `id: "hildegarde-2026"` and change the `hero` and all `photos` entries to `pub("hildegarde/Hildegarde*.jpg")` so they match the uploaded files in `public/hildegarde`, and commit the change (`Fix Hildegarde photo paths`).

### Testing
- Ran `npm run build` which completed successfully, started the dev server and verified `curl -I http://127.0.0.1:5173/hildegarde/Hildegarde15.jpg` returned HTTP 200, and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e5c5139f0832b8b4f60837dc568c6)