### PR TITLE
Interactive stained-glass collage gallery

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1217,29 +1217,40 @@ const Portfolio = () => {
                 </div>
               </div>
               {!viewingImage ? (
-                <motion.div initial={{opacity:0, y:12}} animate={{opacity:1, y:0}} transition={{duration:0.45}} className="grid grid-cols-1 gap-4 pb-8 sm:grid-cols-2 lg:grid-cols-3">
-                  {active.photos.map((src, photoIdx) => (
-                    <button
-                      key={src}
-                      onClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
-                      className="group overflow-hidden rounded-2xl bg-zinc-900 text-left shadow-2xl ring-1 ring-white/10 transition duration-300 hover:-translate-y-1 hover:ring-white/40 focus:outline-none focus:ring-2 focus:ring-white"
-                      aria-label={`Open image ${photoIdx + 1} from ${active.title}`}
-                    >
-                      <div className="aspect-[4/3] overflow-hidden bg-black">
+                <motion.div
+                  initial={{opacity:0, y:12}}
+                  animate={{opacity:1, y:0}}
+                  transition={{duration:0.45}}
+                  className="stained-gallery pb-10"
+                  style={{ '--pane-count': active.photos.length }}
+                >
+                  <div className="stained-gallery__lead" aria-hidden="true">
+                    <Sparkles className="h-4 w-4" />
+                    Interactive stained-glass collage
+                  </div>
+                  <div className="stained-gallery__grid">
+                    {active.photos.map((src, photoIdx) => (
+                      <button
+                        key={src}
+                        onClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
+                        className="stained-pane group"
+                        style={{ '--pane': photoIdx }}
+                        aria-label={`Open image ${photoIdx + 1} from ${active.title}`}
+                      >
                         <img
                           src={src}
                           alt={active.captions?.[photoIdx] || `${active.title} production photo ${photoIdx + 1}`}
-                          className="h-full w-full object-cover transition duration-500 group-hover:scale-105"
                           loading="lazy"
                           decoding="async"
                         />
-                      </div>
-                      <div className="p-4 text-white">
-                        <div className="text-xs uppercase tracking-[0.2em] text-white/50">Photo {photoIdx + 1} of {active.photos.length}</div>
-                        {active.captions?.[photoIdx] && <p className="mt-2 line-clamp-2 text-sm text-white/80">{active.captions[photoIdx]}</p>}
-                      </div>
-                    </button>
-                  ))}
+                        <span className="stained-pane__shine" aria-hidden="true" />
+                        <span className="stained-pane__caption">
+                          <span className="stained-pane__kicker">Photo {photoIdx + 1} / {active.photos.length}</span>
+                          {active.captions?.[photoIdx] && <span className="stained-pane__text">{active.captions[photoIdx]}</span>}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
                 </motion.div>
               ) : (
                 <>

--- a/src/index.css
+++ b/src/index.css
@@ -20,3 +20,196 @@ img, video, canvas {
 /* handy opt-in helpers if you want them */
 img[data-fit="cover"]   { width: 100%; height: 100%; object-fit: cover;  object-position: center; }
 img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object-position: center; }
+
+/* --- portfolio gallery: interactive stained-glass collage --- */
+.stained-gallery {
+  position: relative;
+  isolation: isolate;
+  border-radius: 2rem;
+  padding: clamp(1rem, 2vw, 1.5rem);
+  background:
+    radial-gradient(circle at 15% 10%, rgba(252, 211, 77, 0.22), transparent 26rem),
+    radial-gradient(circle at 85% 16%, rgba(56, 189, 248, 0.18), transparent 24rem),
+    radial-gradient(circle at 50% 100%, rgba(244, 63, 94, 0.18), transparent 26rem),
+    linear-gradient(135deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02));
+  box-shadow: 0 2rem 6rem rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255,255,255,0.12);
+}
+
+.stained-gallery::before {
+  content: "";
+  position: absolute;
+  inset: 0.5rem;
+  z-index: -1;
+  border-radius: 1.5rem;
+  background-image:
+    linear-gradient(120deg, rgba(255,255,255,0.12) 1px, transparent 1px),
+    linear-gradient(35deg, rgba(255,255,255,0.08) 1px, transparent 1px);
+  background-size: 5rem 5rem, 7rem 7rem;
+  mask-image: radial-gradient(circle at center, black, transparent 78%);
+}
+
+.stained-gallery__lead {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  color: rgba(255,255,255,0.72);
+  font-size: 0.72rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.stained-gallery__grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  grid-auto-rows: clamp(8rem, 14vw, 12rem);
+  grid-auto-flow: dense;
+  gap: clamp(0.45rem, 0.8vw, 0.75rem);
+}
+
+.stained-pane {
+  --tilt: calc((var(--pane) - (var(--pane-count) / 2)) * 0.18deg);
+  position: relative;
+  min-height: 10rem;
+  overflow: hidden;
+  color: white;
+  background: #050505;
+  clip-path: polygon(7% 0, 100% 4%, 94% 100%, 0 92%);
+  grid-column: span 4;
+  grid-row: span 2;
+  transform: rotate(var(--tilt));
+  border: 0;
+  box-shadow:
+    inset 0 0 0 2px rgba(255,255,255,0.18),
+    inset 0 0 0 8px rgba(0,0,0,0.34),
+    0 1.25rem 2.75rem rgba(0,0,0,0.45);
+  transition: transform 420ms cubic-bezier(.2,.8,.2,1), filter 420ms ease, clip-path 420ms ease, z-index 0ms;
+}
+
+.stained-pane:nth-child(6n + 1),
+.stained-pane:nth-child(6n + 4) { grid-column: span 5; }
+.stained-pane:nth-child(6n + 2) { grid-column: span 3; clip-path: polygon(0 8%, 92% 0, 100% 92%, 10% 100%); }
+.stained-pane:nth-child(6n + 3) { grid-row: span 3; clip-path: polygon(12% 0, 100% 10%, 88% 100%, 0 88%); }
+.stained-pane:nth-child(6n + 5) { grid-column: span 7; }
+.stained-pane:nth-child(6n) { grid-column: span 5; clip-path: polygon(0 0, 92% 8%, 100% 100%, 6% 94%); }
+
+.stained-pane img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  filter: saturate(1.16) contrast(1.06) brightness(0.9);
+  transform: scale(1.04);
+  transition: transform 650ms cubic-bezier(.2,.8,.2,1), filter 420ms ease;
+}
+
+.stained-pane::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(135deg, rgba(255,255,255,0.24), transparent 32%, rgba(0,0,0,0.32)),
+    radial-gradient(circle at 80% 10%, rgba(255,255,255,0.22), transparent 22rem);
+  mix-blend-mode: screen;
+  opacity: 0.55;
+}
+
+.stained-pane__shine {
+  position: absolute;
+  inset: -35%;
+  pointer-events: none;
+  background: linear-gradient(105deg, transparent 34%, rgba(255,255,255,0.42), transparent 52%);
+  transform: translateX(-70%) rotate(12deg);
+  transition: transform 700ms ease;
+}
+
+.stained-pane__caption {
+  position: absolute;
+  inset-inline: 0.85rem;
+  bottom: 0.85rem;
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  text-align: left;
+  border: 1px solid rgba(255,255,255,0.16);
+  border-radius: 1rem;
+  background: linear-gradient(180deg, rgba(0,0,0,0.08), rgba(0,0,0,0.72));
+  backdrop-filter: blur(10px);
+  transform: translateY(calc(100% - 1.8rem));
+  transition: transform 360ms ease, background 360ms ease;
+}
+
+.stained-pane__kicker {
+  font-size: 0.68rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.72);
+}
+
+.stained-pane__text {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  font-size: 0.88rem;
+  line-height: 1.35;
+  color: rgba(255,255,255,0.88);
+}
+
+.stained-gallery__grid:has(.stained-pane:hover) .stained-pane:not(:hover) {
+  filter: brightness(0.64) saturate(0.82);
+}
+
+.stained-pane:hover,
+.stained-pane:focus-visible {
+  z-index: 5;
+  clip-path: polygon(3% 0, 100% 2%, 97% 100%, 0 98%);
+  transform: scale(1.075) rotate(0deg);
+  outline: none;
+  box-shadow:
+    inset 0 0 0 2px rgba(255,255,255,0.34),
+    inset 0 0 0 9px rgba(0,0,0,0.32),
+    0 2rem 4rem rgba(0,0,0,0.62),
+    0 0 3.5rem rgba(255,255,255,0.18);
+}
+
+.stained-pane:hover img,
+.stained-pane:focus-visible img {
+  filter: saturate(1.32) contrast(1.12) brightness(1.04);
+  transform: scale(1.14);
+}
+
+.stained-pane:hover .stained-pane__shine,
+.stained-pane:focus-visible .stained-pane__shine {
+  transform: translateX(70%) rotate(12deg);
+}
+
+.stained-pane:hover .stained-pane__caption,
+.stained-pane:focus-visible .stained-pane__caption {
+  background: linear-gradient(180deg, rgba(0,0,0,0.16), rgba(0,0,0,0.78));
+  transform: translateY(0);
+}
+
+@media (max-width: 900px) {
+  .stained-gallery__grid { grid-auto-rows: clamp(7rem, 24vw, 11rem); }
+  .stained-pane,
+  .stained-pane:nth-child(n) { grid-column: span 6; grid-row: span 2; }
+  .stained-pane:nth-child(4n + 1) { grid-column: span 12; }
+}
+
+@media (max-width: 640px) {
+  .stained-gallery { border-radius: 1.25rem; padding: 0.75rem; }
+  .stained-gallery__grid { display: flex; gap: 0.75rem; overflow-x: auto; scroll-snap-type: x mandatory; padding-bottom: 0.5rem; }
+  .stained-pane,
+  .stained-pane:nth-child(n) { flex: 0 0 82%; min-height: 22rem; scroll-snap-align: center; }
+  .stained-pane__caption { transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stained-pane,
+  .stained-pane img,
+  .stained-pane__shine,
+  .stained-pane__caption { transition: none; }
+  .stained-pane:hover,
+  .stained-pane:focus-visible { transform: none; }
+}


### PR DESCRIPTION
### Motivation

- Make the portfolio gallery more artistic, dynamic, and visually distinctive by replacing the standard grid with an interactive stained-glass collage that highlights photos as tactile, asymmetric panes and responds to hover/touch.
- Preserve existing lightbox navigation and accessibility while adding expressive visuals so the gallery reads as a designer-forward piece that can impress industry visitors.

### Description

- Replaced the modal gallery grid markup with a new stained-glass collage in `src/App.jsx`, adding a `stained-gallery` container, per-photo `stained-pane` buttons, a small lead label and `--pane`/`--pane-count` CSS variables to drive layout and tilt.
- Added a large CSS feature set to `src/index.css` implementing layered ambient gradients, asymmetric `clip-path` panes, tilt/hover expansion, shimmer overlays, caption reveals, neighbor-dimming, responsive behavior (tablet grid and horizontal snap on mobile), and `prefers-reduced-motion` handling.
- Kept the existing lightbox behavior, keyboard navigation, swipe support, and ARIA attributes so clicking/tapping a pane still opens the larger viewer with previous/next controls.
- Made only UI/visual enhancements (no changes to data model or project assets), and ensured captions and focus states remain accessible.

### Testing

- Ran a production build with `npm run build`, which completed successfully (built assets and CSS); there was a bundle-size warning but the build succeeded.
- Started the dev server via `npm run dev` in the background to smoke-test the site (process started), but no headless browser end-to-end screenshot tests were run.
- Attempted to run automated browser checks but CI/local environment lacked `playwright` and browser binaries, so those checks could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e74705b54832bb6f2f4c2935dfd1c)