### PR TITLE
Refine portfolio gallery masonry layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1226,7 +1226,7 @@ const Portfolio = () => {
                 >
                   <div className="stained-gallery__lead" aria-hidden="true">
                     <Sparkles className="h-4 w-4" />
-                    Interactive stained-glass collage
+                    Production photo wall
                   </div>
                   <div className="stained-gallery__grid">
                     {active.photos.map((src, photoIdx) => (

--- a/src/index.css
+++ b/src/index.css
@@ -21,18 +21,17 @@ img, video, canvas {
 img[data-fit="cover"]   { width: 100%; height: 100%; object-fit: cover;  object-position: center; }
 img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object-position: center; }
 
-/* --- portfolio gallery: interactive stained-glass collage --- */
+/* --- portfolio gallery: polished Pinterest-style masonry wall --- */
 .stained-gallery {
   position: relative;
   isolation: isolate;
-  border-radius: 2rem;
-  padding: clamp(1rem, 2vw, 1.5rem);
+  border-radius: 1.75rem;
+  padding: clamp(0.65rem, 1.4vw, 1.1rem);
   background:
-    radial-gradient(circle at 15% 10%, rgba(252, 211, 77, 0.22), transparent 26rem),
-    radial-gradient(circle at 85% 16%, rgba(56, 189, 248, 0.18), transparent 24rem),
-    radial-gradient(circle at 50% 100%, rgba(244, 63, 94, 0.18), transparent 26rem),
-    linear-gradient(135deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02));
-  box-shadow: 0 2rem 6rem rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255,255,255,0.12);
+    radial-gradient(circle at 12% 0%, rgba(251, 191, 36, 0.12), transparent 22rem),
+    radial-gradient(circle at 88% 8%, rgba(96, 165, 250, 0.10), transparent 22rem),
+    linear-gradient(145deg, rgba(255,255,255,0.08), rgba(255,255,255,0.025));
+  box-shadow: 0 1.5rem 4.5rem rgba(0, 0, 0, 0.48), inset 0 0 0 1px rgba(255,255,255,0.10);
 }
 
 .stained-gallery::before {
@@ -40,19 +39,16 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   position: absolute;
   inset: 0.5rem;
   z-index: -1;
-  border-radius: 1.5rem;
-  background-image:
-    linear-gradient(120deg, rgba(255,255,255,0.12) 1px, transparent 1px),
-    linear-gradient(35deg, rgba(255,255,255,0.08) 1px, transparent 1px);
-  background-size: 5rem 5rem, 7rem 7rem;
-  mask-image: radial-gradient(circle at center, black, transparent 78%);
+  border-radius: 1.25rem;
+  background: linear-gradient(135deg, rgba(255,255,255,0.08), transparent 45%, rgba(255,255,255,0.04));
+  pointer-events: none;
 }
 
 .stained-gallery__lead {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  margin-bottom: 1rem;
+  margin: 0 0 0.7rem 0.2rem;
   color: rgba(255,255,255,0.72);
   font-size: 0.72rem;
   letter-spacing: 0.22em;
@@ -60,90 +56,79 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 }
 
 .stained-gallery__grid {
-  display: grid;
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-  grid-auto-rows: clamp(8rem, 14vw, 12rem);
-  grid-auto-flow: dense;
-  gap: clamp(0.45rem, 0.8vw, 0.75rem);
+  column-count: 3;
+  column-gap: clamp(0.45rem, 0.85vw, 0.7rem);
 }
 
 .stained-pane {
-  --tilt: calc((var(--pane) - (var(--pane-count) / 2)) * 0.18deg);
   position: relative;
-  min-height: 10rem;
+  display: block;
+  width: 100%;
+  margin: 0 0 clamp(0.45rem, 0.85vw, 0.7rem);
+  break-inside: avoid;
   overflow: hidden;
   color: white;
   background: #050505;
-  clip-path: polygon(7% 0, 100% 4%, 94% 100%, 0 92%);
-  grid-column: span 4;
-  grid-row: span 2;
-  transform: rotate(var(--tilt));
   border: 0;
-  box-shadow:
-    inset 0 0 0 2px rgba(255,255,255,0.18),
-    inset 0 0 0 8px rgba(0,0,0,0.34),
-    0 1.25rem 2.75rem rgba(0,0,0,0.45);
-  transition: transform 420ms cubic-bezier(.2,.8,.2,1), filter 420ms ease, clip-path 420ms ease, z-index 0ms;
+  border-radius: clamp(0.8rem, 1.6vw, 1.2rem);
+  box-shadow: 0 0.85rem 2.2rem rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255,0.12);
+  transform: translateZ(0);
+  transition: transform 260ms cubic-bezier(.2,.8,.2,1), filter 260ms ease, box-shadow 260ms ease;
 }
-
-.stained-pane:nth-child(6n + 1),
-.stained-pane:nth-child(6n + 4) { grid-column: span 5; }
-.stained-pane:nth-child(6n + 2) { grid-column: span 3; clip-path: polygon(0 8%, 92% 0, 100% 92%, 10% 100%); }
-.stained-pane:nth-child(6n + 3) { grid-row: span 3; clip-path: polygon(12% 0, 100% 10%, 88% 100%, 0 88%); }
-.stained-pane:nth-child(6n + 5) { grid-column: span 7; }
-.stained-pane:nth-child(6n) { grid-column: span 5; clip-path: polygon(0 0, 92% 8%, 100% 100%, 6% 94%); }
 
 .stained-pane img {
+  display: block;
   width: 100%;
-  height: 100%;
+  height: auto;
+  aspect-ratio: 4 / 3;
   object-fit: cover;
-  filter: saturate(1.16) contrast(1.06) brightness(0.9);
-  transform: scale(1.04);
-  transition: transform 650ms cubic-bezier(.2,.8,.2,1), filter 420ms ease;
+  filter: saturate(1.08) contrast(1.04) brightness(0.94);
+  transition: transform 420ms cubic-bezier(.2,.8,.2,1), filter 260ms ease;
 }
+
+.stained-pane:nth-child(5n + 1) img { aspect-ratio: 4 / 5; }
+.stained-pane:nth-child(5n + 2) img { aspect-ratio: 3 / 2; }
+.stained-pane:nth-child(5n + 3) img { aspect-ratio: 1 / 1; }
+.stained-pane:nth-child(5n + 4) img { aspect-ratio: 5 / 4; }
+.stained-pane:nth-child(5n) img { aspect-ratio: 2 / 3; }
 
 .stained-pane::before {
   content: "";
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background:
-    linear-gradient(135deg, rgba(255,255,255,0.24), transparent 32%, rgba(0,0,0,0.32)),
-    radial-gradient(circle at 80% 10%, rgba(255,255,255,0.22), transparent 22rem);
-  mix-blend-mode: screen;
-  opacity: 0.55;
+  background: linear-gradient(180deg, transparent 45%, rgba(0,0,0,0.74));
+  opacity: 0.78;
+  transition: opacity 260ms ease;
 }
 
 .stained-pane__shine {
   position: absolute;
-  inset: -35%;
+  inset: 0;
   pointer-events: none;
-  background: linear-gradient(105deg, transparent 34%, rgba(255,255,255,0.42), transparent 52%);
-  transform: translateX(-70%) rotate(12deg);
-  transition: transform 700ms ease;
+  background: radial-gradient(circle at 20% 10%, rgba(255,255,255,0.20), transparent 36%);
+  opacity: 0;
+  transition: opacity 260ms ease;
 }
 
 .stained-pane__caption {
   position: absolute;
-  inset-inline: 0.85rem;
-  bottom: 0.85rem;
+  inset-inline: 0.75rem;
+  bottom: 0.75rem;
   display: grid;
-  gap: 0.35rem;
-  padding: 0.75rem;
+  gap: 0.25rem;
+  padding: 0;
   text-align: left;
-  border: 1px solid rgba(255,255,255,0.16);
-  border-radius: 1rem;
-  background: linear-gradient(180deg, rgba(0,0,0,0.08), rgba(0,0,0,0.72));
-  backdrop-filter: blur(10px);
-  transform: translateY(calc(100% - 1.8rem));
-  transition: transform 360ms ease, background 360ms ease;
+  transform: translateY(calc(100% - 1.35rem));
+  transition: transform 260ms ease;
 }
 
 .stained-pane__kicker {
-  font-size: 0.68rem;
-  letter-spacing: 0.2em;
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(255,255,255,0.72);
+  color: rgba(255,255,255,0.78);
+  text-shadow: 0 1px 8px rgba(0,0,0,0.65);
 }
 
 .stained-pane__text {
@@ -151,57 +136,47 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   overflow: hidden;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
-  font-size: 0.88rem;
+  font-size: 0.84rem;
   line-height: 1.35;
-  color: rgba(255,255,255,0.88);
+  color: rgba(255,255,255,0.9);
+  text-shadow: 0 1px 10px rgba(0,0,0,0.8);
 }
 
 .stained-gallery__grid:has(.stained-pane:hover) .stained-pane:not(:hover) {
-  filter: brightness(0.64) saturate(0.82);
+  filter: brightness(0.78) saturate(0.88);
 }
 
 .stained-pane:hover,
 .stained-pane:focus-visible {
-  z-index: 5;
-  clip-path: polygon(3% 0, 100% 2%, 97% 100%, 0 98%);
-  transform: scale(1.075) rotate(0deg);
+  z-index: 3;
+  transform: translateY(-0.25rem) scale(1.018);
   outline: none;
-  box-shadow:
-    inset 0 0 0 2px rgba(255,255,255,0.34),
-    inset 0 0 0 9px rgba(0,0,0,0.32),
-    0 2rem 4rem rgba(0,0,0,0.62),
-    0 0 3.5rem rgba(255,255,255,0.18);
+  box-shadow: 0 1.4rem 3rem rgba(0,0,0,0.54), 0 0 0 1px rgba(255,255,255,0.24);
 }
 
 .stained-pane:hover img,
 .stained-pane:focus-visible img {
-  filter: saturate(1.32) contrast(1.12) brightness(1.04);
-  transform: scale(1.14);
+  filter: saturate(1.2) contrast(1.08) brightness(1.02);
+  transform: scale(1.045);
 }
 
+.stained-pane:hover::before,
+.stained-pane:focus-visible::before { opacity: 0.92; }
 .stained-pane:hover .stained-pane__shine,
-.stained-pane:focus-visible .stained-pane__shine {
-  transform: translateX(70%) rotate(12deg);
-}
-
+.stained-pane:focus-visible .stained-pane__shine { opacity: 1; }
 .stained-pane:hover .stained-pane__caption,
-.stained-pane:focus-visible .stained-pane__caption {
-  background: linear-gradient(180deg, rgba(0,0,0,0.16), rgba(0,0,0,0.78));
-  transform: translateY(0);
-}
+.stained-pane:focus-visible .stained-pane__caption { transform: translateY(0); }
 
 @media (max-width: 900px) {
-  .stained-gallery__grid { grid-auto-rows: clamp(7rem, 24vw, 11rem); }
-  .stained-pane,
-  .stained-pane:nth-child(n) { grid-column: span 6; grid-row: span 2; }
-  .stained-pane:nth-child(4n + 1) { grid-column: span 12; }
+  .stained-gallery__grid { column-count: 2; }
 }
 
 @media (max-width: 640px) {
-  .stained-gallery { border-radius: 1.25rem; padding: 0.75rem; }
-  .stained-gallery__grid { display: flex; gap: 0.75rem; overflow-x: auto; scroll-snap-type: x mandatory; padding-bottom: 0.5rem; }
-  .stained-pane,
-  .stained-pane:nth-child(n) { flex: 0 0 82%; min-height: 22rem; scroll-snap-align: center; }
+  .stained-gallery { border-radius: 1.25rem; padding: 0.55rem; }
+  .stained-gallery__grid { column-count: 1; column-gap: 0; }
+  .stained-pane { margin-bottom: 0.6rem; border-radius: 1rem; }
+  .stained-pane img,
+  .stained-pane:nth-child(n) img { aspect-ratio: 4 / 5; }
   .stained-pane__caption { transform: translateY(0); }
 }
 


### PR DESCRIPTION
### Motivation
- Make the portfolio gallery visually tighter and more photograph-forward so images read like a Pinterest-style masonry wall rather than a spaced, abstract collage. 
- Reduce large gaps between photos and remove heavy polygon/tilt treatments so the gallery feels cleaner and more cohesive. 
- Improve responsiveness and hover behavior so the gallery is pleasant on desktop, tablet, and mobile.

### Description
- Replace the previous grid/tilted "stained-glass" layout with a column-based masonry approach by switching `.stained-gallery__grid` to `column-count` and using `break-inside: avoid` on `.stained-pane` to pack photos tightly. 
- Remove clip-path/rotation tilt styling and add varied `aspect-ratio` rules for tiles, rounded corners, reduced gaps, and updated shadow/hover treatments for subtler zoom and improved caption reveal. 
- Update gallery container styling for a softer, polished look and adjust responsive rules to use 3 columns (desktop), 2 columns (tablet), and 1 column (mobile). 
- Change the gallery label text in `src/App.jsx` from "Interactive stained-glass collage" to "Production photo wall" to match the new visual direction.

### Testing
- Ran a production build with `npm run build`, which completed successfully. 
- Started the dev server with `npm run dev`, and Vite reported the app ready and serving (local network address returned). 
- Attempted an automated screenshot via Playwright but the environment lacks Playwright, so the screenshot step could not run (dependency missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e7e2729a8832bbe639a6836b8fd27)