### PR TITLE
Interactive shifting-pane gallery with animated spotlight and responsive grid

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1089,6 +1089,7 @@ const ProjectCard = ({ project }) => {
 const Portfolio = () => {
   const [active, setActive] = useState(null);
   const [idx, setIdx] = useState(null);
+  const [spotlightIdx, setSpotlightIdx] = useState(0);
   const [copied, setCopied] = useState(false);
   const viewingImage = idx !== null;
   const next = useCallback(() => setIdx(i => {
@@ -1114,14 +1115,14 @@ const Portfolio = () => {
       const [base, id] = hash.split('/');
       if (base === 'portfolio' && id) {
         const p = PROJECTS.find(p => p.id === id);
-        if (p) { setActive(p); setIdx(null); }
+        if (p) { setActive(p); setIdx(null); setSpotlightIdx(0); }
       }
     };
     apply();
     window.addEventListener('hashchange', apply);
     return () => window.removeEventListener('hashchange', apply);
   }, []);
-  useEffect(()=>{ const onKey = (e)=>{ if(!active) return; if(e.key==='Escape') { viewingImage ? setIdx(null) : close(); } if(viewingImage && e.key==='ArrowRight') next(); if(viewingImage && e.key==='ArrowLeft') prev(); }; const onOpen = (e) => { if(e.detail){ setActive(e.detail); setIdx(null);} }; window.addEventListener('keydown', onKey); window.addEventListener('openGallery', onOpen); return ()=>{ window.removeEventListener('keydown', onKey); window.removeEventListener('openGallery', onOpen); }; },[active, close, next, prev, viewingImage]);
+  useEffect(()=>{ const onKey = (e)=>{ if(!active) return; if(e.key==='Escape') { viewingImage ? setIdx(null) : close(); } if(viewingImage && e.key==='ArrowRight') next(); if(viewingImage && e.key==='ArrowLeft') prev(); }; const onOpen = (e) => { if(e.detail){ setActive(e.detail); setIdx(null); setSpotlightIdx(0);} }; window.addEventListener('keydown', onKey); window.addEventListener('openGallery', onOpen); return ()=>{ window.removeEventListener('keydown', onKey); window.removeEventListener('openGallery', onOpen); }; },[active, close, next, prev, viewingImage]);
   useEffect(() => { let id = null; try { id = sessionStorage.getItem('openGalleryId'); } catch(e){} if (id) { const p = PROJECTS.find(p=>p.id===id); if (p) { setActive(p); setIdx(null); } try { sessionStorage.removeItem('openGalleryId'); } catch(e){} } }, []);
   useEffect(() => { setImgLoaded(false); setCopied(false); }, [idx, active]);
   useEffect(() => {
@@ -1201,7 +1202,7 @@ const Portfolio = () => {
                   <div className="text-xs uppercase tracking-[0.2em] opacity-80">{active.role} — {active.year}</div>
                   <div className="text-2xl font-serif font-semibold">{active.title}</div>
                   <p className="mt-1 text-sm text-white/65">
-                    {viewingImage ? 'Use the arrows to move through the selected photo, or return to the full gallery.' : 'Select any production photo to open a larger, window-friendly view.'}
+                    {viewingImage ? 'Use the arrows to move through the selected photo, or return to the full gallery.' : 'Choose a pane to bring it forward. The rest of the wall will reshape around it.'}
                   </p>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
@@ -1241,16 +1242,28 @@ const Portfolio = () => {
                 >
                   <div className="stained-gallery__lead" aria-hidden="true">
                     <Sparkles className="h-4 w-4" />
-                    Production photo wall
+                    Interactive production wall
                   </div>
                   <div className="stained-gallery__grid">
                     {active.photos.map((src, photoIdx) => (
-                      <button
+                      <motion.button
                         key={src}
-                        onClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
-                        className="stained-pane group"
+                        layout
+                        transition={{ layout: { duration: 0.62, type: 'spring', bounce: 0.08 } }}
+                        onClick={() => {
+                          if (spotlightIdx === photoIdx) {
+                            setIdx(photoIdx);
+                            track('gallery_select_image', { project_id: active.id, idx: photoIdx });
+                          } else {
+                            setSpotlightIdx(photoIdx);
+                            track('gallery_select_pane', { project_id: active.id, idx: photoIdx });
+                          }
+                        }}
+                        onDoubleClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
+                        className={`stained-pane group ${spotlightIdx === photoIdx ? 'is-active' : ''}`}
                         style={{ '--pane': photoIdx }}
-                        aria-label={`Open image ${photoIdx + 1} from ${active.title}`}
+                        aria-label={`${spotlightIdx === photoIdx ? 'Featured' : 'Feature'} image ${photoIdx + 1} from ${active.title}`}
+                        aria-pressed={spotlightIdx === photoIdx}
                       >
                         <img
                           src={src}
@@ -1263,7 +1276,10 @@ const Portfolio = () => {
                           <span className="stained-pane__kicker">Photo {photoIdx + 1} / {active.photos.length}</span>
                           {active.captions?.[photoIdx] && <span className="stained-pane__text">{active.captions[photoIdx]}</span>}
                         </span>
-                      </button>
+                        {spotlightIdx === photoIdx && (
+                          <span className="stained-pane__expand">View full image <ChevronRight className="h-4 w-4" /></span>
+                        )}
+                      </motion.button>
                     ))}
                   </div>
                 </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -21,7 +21,7 @@ img, video, canvas {
 img[data-fit="cover"]   { width: 100%; height: 100%; object-fit: cover;  object-position: center; }
 img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object-position: center; }
 
-/* --- portfolio gallery: polished Pinterest-style masonry wall --- */
+/* --- portfolio gallery: responsive, shifting pane wall --- */
 .stained-gallery {
   position: relative;
   isolation: isolate;
@@ -56,16 +56,19 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 }
 
 .stained-gallery__grid {
-  column-count: 3;
-  column-gap: clamp(0.45rem, 0.85vw, 0.7rem);
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  grid-auto-flow: dense;
+  grid-auto-rows: clamp(4.4rem, 7.2vw, 6.5rem);
+  gap: clamp(0.35rem, 0.7vw, 0.6rem);
 }
 
 .stained-pane {
   position: relative;
   display: block;
   width: 100%;
-  margin: 0 0 clamp(0.45rem, 0.85vw, 0.7rem);
-  break-inside: avoid;
+  grid-column: span 3;
+  grid-row: span 2;
   overflow: hidden;
   color: white;
   background: #050505;
@@ -73,24 +76,31 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   border-radius: clamp(0.8rem, 1.6vw, 1.2rem);
   box-shadow: 0 0.85rem 2.2rem rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255,0.12);
   transform: translateZ(0);
-  transition: transform 260ms cubic-bezier(.2,.8,.2,1), filter 260ms ease, box-shadow 260ms ease;
+  transition: transform 420ms cubic-bezier(.2,.8,.2,1), filter 420ms ease, box-shadow 420ms ease, border-radius 420ms ease;
+}
+
+.stained-pane:nth-child(6n + 2),
+.stained-pane:nth-child(6n + 5) { grid-column: span 4; }
+.stained-pane:nth-child(6n + 3) { grid-column: span 5; }
+.stained-pane:nth-child(6n + 4) { grid-row: span 3; }
+.stained-pane.is-active {
+  z-index: 4;
+  grid-column: span 8;
+  grid-row: span 5;
+  border-radius: clamp(1rem, 2vw, 1.5rem);
+  box-shadow: 0 2rem 4rem rgba(0,0,0,0.58), 0 0 0 1px rgba(255,255,255,0.28);
 }
 
 .stained-pane img {
   display: block;
   width: 100%;
-  height: auto;
-  aspect-ratio: 4 / 3;
+  height: 100%;
   object-fit: cover;
   filter: saturate(1.08) contrast(1.04) brightness(0.94);
   transition: transform 420ms cubic-bezier(.2,.8,.2,1), filter 260ms ease;
 }
 
-.stained-pane:nth-child(5n + 1) img { aspect-ratio: 4 / 5; }
-.stained-pane:nth-child(5n + 2) img { aspect-ratio: 3 / 2; }
-.stained-pane:nth-child(5n + 3) img { aspect-ratio: 1 / 1; }
-.stained-pane:nth-child(5n + 4) img { aspect-ratio: 5 / 4; }
-.stained-pane:nth-child(5n) img { aspect-ratio: 2 / 3; }
+.stained-pane.is-active img { object-fit: contain; transform: scale(0.965); }
 
 .stained-pane::before {
   content: "";
@@ -142,6 +152,23 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   text-shadow: 0 1px 10px rgba(0,0,0,0.8);
 }
 
+.stained-pane__expand {
+  position: absolute;
+  top: 0.85rem;
+  right: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.75rem;
+  border: 1px solid rgba(255,255,255,0.45);
+  border-radius: 999px;
+  background: rgba(0,0,0,0.62);
+  backdrop-filter: blur(10px);
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
 .stained-gallery__grid:has(.stained-pane:hover) .stained-pane:not(:hover) {
   filter: brightness(0.78) saturate(0.88);
 }
@@ -168,15 +195,18 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 .stained-pane:focus-visible .stained-pane__caption { transform: translateY(0); }
 
 @media (max-width: 900px) {
-  .stained-gallery__grid { column-count: 2; }
+  .stained-gallery__grid { grid-template-columns: repeat(8, minmax(0, 1fr)); }
+  .stained-pane { grid-column: span 4; }
+  .stained-pane:nth-child(n) { grid-column: span 4; }
+  .stained-pane.is-active { grid-column: span 8; grid-row: span 4; }
 }
 
 @media (max-width: 640px) {
   .stained-gallery { border-radius: 1.25rem; padding: 0.55rem; }
-  .stained-gallery__grid { column-count: 1; column-gap: 0; }
-  .stained-pane { margin-bottom: 0.6rem; border-radius: 1rem; }
-  .stained-pane img,
-  .stained-pane:nth-child(n) img { aspect-ratio: 4 / 5; }
+  .stained-gallery__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 7rem; gap: 0.4rem; }
+  .stained-pane,
+  .stained-pane:nth-child(n) { grid-column: span 1; grid-row: span 2; border-radius: 0.75rem; }
+  .stained-pane.is-active { grid-column: 1 / -1; grid-row: span 4; }
   .stained-pane__caption { transform: translateY(0); }
 }
 


### PR DESCRIPTION
### Motivation

- Replace the static masonry photo wall with a sleek, interactive gallery that highlights a selected pane and lets the surrounding panes smoothly reshape around it to present images more dramatically.

### Description

- Introduce a spotlight state (`spotlightIdx`) and change pane interactions so a click marks a pane as the spotlight and a second click or double-click opens the full-screen lightbox; analytics events were added for pane selection and spotlighting.
- Animate layout transitions using `framer-motion` (`motion.button` with `layout` and a spring transition) so the selected pane expands and neighboring panes reflow smoothly.
- Replace the column-based masonry CSS with a dense CSS Grid in `src/index.css`, add varied span rules and an `.is-active` modifier to make the featured pane span multiple rows/columns and apply deeper shadows and refined hover effects.
- Preserve existing accessibility and navigation features including keyboard navigation, swipe handling, focus trapping inside the dialog, captions, and a clear affordance for viewing the full image.

### Testing

- `npm run build` completed successfully (Vite production build finished), and the app bundles were produced, with Vite noting an advisory about a large Three.js chunk but not failing the build.
- `git diff --check` was run and reported no check failures.
- `git status --short --branch` was inspected to confirm the working tree state after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80b70c19bc832b945069c7524b5ae4)