### PR TITLE
Refine interactive gallery behavior and redesign contact page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Play, Square, Mail, Phone, MapPin, ChevronLeft, ChevronRight, Instagram, Linkedin, Music2, FileDown, Eye, Printer, CheckCircle2, X, Sparkles, Grid3X3 } from "lucide-react";
+import { Play, Square, Mail, Phone, MapPin, ChevronLeft, ChevronRight, Instagram, Linkedin, Music2, FileDown, Eye, Printer, CheckCircle2, X, Grid3X3, ArrowUpRight } from "lucide-react";
 
 // ---- GA helper (idempotent) ----------------------------------------------
 if (typeof window !== 'undefined' && !window.__hkTrack) {
@@ -450,11 +450,11 @@ const injectFonts = () => {
     head.appendChild(l);
   }
 
-  if (!head.querySelector('link[data-font="inter"]')) {
+  if (!head.querySelector('link[data-font="jost"]')) {
     const l = document.createElement('link');
     l.rel = 'stylesheet';
-    l.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap';
-    l.setAttribute('data-font', 'inter');
+    l.href = 'https://fonts.googleapis.com/css2?family=Jost:wght@300;400;500;600&display=swap';
+    l.setAttribute('data-font', 'jost');
     head.appendChild(l);
   }
 };
@@ -1193,7 +1193,10 @@ const Portfolio = () => {
             aria-label={`${active.title} gallery`}
             aria-keyshortcuts="ArrowLeft ArrowRight Escape"
             onClick={(e) => {
-              if (e.currentTarget === e.target) { close(); track('gallery_close_backdrop', { project_id: active.id }); }
+              if (e.currentTarget === e.target) {
+                if (viewingImage) setIdx(null); else close();
+                track('gallery_close_backdrop', { project_id: active.id });
+              }
             }}
           >
             <div className="max-w-6xl mx-auto">
@@ -1227,8 +1230,12 @@ const Portfolio = () => {
                     title="Copy gallery link" aria-label="Copy gallery link"
                     className="rounded-full border border-white/30 px-3 py-1 text-white hover:bg-white hover:text-black transition">{copied ? 'Copied!' : 'Copy Link'}</button>
                   <button
-                    onClick={() => { close(); track('gallery_close', { project_id: active.id }); }}
-                    title="Close gallery" aria-label="Close gallery"
+                    onClick={() => {
+                      if (viewingImage) setIdx(null); else close();
+                      track('gallery_close', { project_id: active.id, destination: viewingImage ? 'gallery' : 'portfolio' });
+                    }}
+                    title={viewingImage ? "Close image and return to gallery" : "Close gallery"}
+                    aria-label={viewingImage ? "Close image and return to gallery" : "Close gallery"}
                     className="rounded-full border border-white/30 px-3 py-1 text-white hover:bg-white hover:text-black transition">Close</button>
                 </div>
               </div>
@@ -1237,29 +1244,18 @@ const Portfolio = () => {
                   initial={{opacity:0, y:12}}
                   animate={{opacity:1, y:0}}
                   transition={{duration:0.45}}
-                  className="stained-gallery pb-10"
+                  className="stained-gallery"
                   style={{ '--pane-count': active.photos.length }}
                 >
-                  <div className="stained-gallery__lead" aria-hidden="true">
-                    <Sparkles className="h-4 w-4" />
-                    Interactive production wall
-                  </div>
                   <div className="stained-gallery__grid">
                     {active.photos.map((src, photoIdx) => (
                       <motion.button
                         key={src}
                         layout
                         transition={{ layout: { duration: 0.62, type: 'spring', bounce: 0.08 } }}
-                        onClick={() => {
-                          if (spotlightIdx === photoIdx) {
-                            setIdx(photoIdx);
-                            track('gallery_select_image', { project_id: active.id, idx: photoIdx });
-                          } else {
-                            setSpotlightIdx(photoIdx);
-                            track('gallery_select_pane', { project_id: active.id, idx: photoIdx });
-                          }
-                        }}
-                        onDoubleClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
+                        onMouseEnter={() => setSpotlightIdx(photoIdx)}
+                        onFocus={() => setSpotlightIdx(photoIdx)}
+                        onClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
                         className={`stained-pane group ${spotlightIdx === photoIdx ? 'is-active' : ''}`}
                         style={{ '--pane': photoIdx }}
                         aria-label={`${spotlightIdx === photoIdx ? 'Featured' : 'Feature'} image ${photoIdx + 1} from ${active.title}`}
@@ -1271,14 +1267,6 @@ const Portfolio = () => {
                           loading="lazy"
                           decoding="async"
                         />
-                        <span className="stained-pane__shine" aria-hidden="true" />
-                        <span className="stained-pane__caption">
-                          <span className="stained-pane__kicker">Photo {photoIdx + 1} / {active.photos.length}</span>
-                          {active.captions?.[photoIdx] && <span className="stained-pane__text">{active.captions[photoIdx]}</span>}
-                        </span>
-                        {spotlightIdx === photoIdx && (
-                          <span className="stained-pane__expand">View full image <ChevronRight className="h-4 w-4" /></span>
-                        )}
                       </motion.button>
                     ))}
                   </div>
@@ -1526,32 +1514,38 @@ const Resume = () => {
 };
 
 const Contact = () => (
-  <section className="py-24 px-6 bg-black text-white">
-    <SectionTitle>Contact</SectionTitle>
-    <div className="mx-auto max-w-5xl grid md:grid-cols-12 gap-10">
-      <div className="md:col-span-6 space-y-4 text-lg">
-        <p className="opacity-90">New projects, assisting, tours, concerts — I’d love to connect.</p>
-        <div>
-          <Mail className="inline mr-2"/>
+  <section className="contact-page py-28 px-6 bg-black text-white">
+    <div className="mx-auto max-w-5xl">
+      <p className="contact-eyebrow">Let’s make something memorable</p>
+      <h1 className="contact-heading">Have a stage in mind?</h1>
+      <p className="contact-intro">New projects, assisting, tours, concerts — I’d love to hear what you’re creating.</p>
+      <div className="contact-grid">
+        <div className="contact-card contact-card--primary">
+          <Mail className="contact-icon" aria-hidden="true"/>
+          <span className="contact-label">Email</span>
           <a
             href={`mailto:${LINKS.email}`}
-            className="underline"
+            className="contact-link"
             onClick={() => track('contact_email_click', { email: LINKS.email })}
-          >{LINKS.email}</a>
+          >{LINKS.email}<ArrowUpRight aria-hidden="true" /></a>
         </div>
-        <div>
-          <Phone className="inline mr-2"/>
+        <div className="contact-card">
+          <Phone className="contact-icon" aria-hidden="true"/>
+          <span className="contact-label">Phone</span>
           <a
             href={`tel:${LINKS.phone.replace(/[^+\d]/g,'')}`}
-            className="underline"
+            className="contact-link"
             onClick={() => track('contact_phone_click', { phone: LINKS.phone })}
-          >{LINKS.phone}</a>
+          >{LINKS.phone}<ArrowUpRight aria-hidden="true" /></a>
         </div>
-        <div><MapPin className="inline mr-2"/>{LINKS.location}</div>
-      </div>
-      <div className="md:col-span-6">
-        <h3 className="uppercase tracking-widest text-sm opacity-80 mb-3">Find me online</h3>
-        <div className="flex flex-wrap gap-3">
+        <div className="contact-card">
+          <MapPin className="contact-icon" aria-hidden="true"/>
+          <span className="contact-label">Based in</span>
+          <span className="contact-link">{LINKS.location}</span>
+        </div>
+        <div className="contact-card contact-card--social">
+          <span className="contact-label">Elsewhere</span>
+          <div className="flex flex-wrap gap-2">
           {SOCIALS.map(({ key, label, href, Icon }) => (
             <a
               key={key}
@@ -1559,13 +1553,14 @@ const Contact = () => (
               target="_blank"
               rel="noopener noreferrer me"
               onClick={() => track('social_click', { network: key })}
-              className="inline-flex items-center gap-2 border border-white/30 rounded-full px-4 py-2 text-sm hover:bg-white hover:text-black transition"
+              className="contact-social"
               aria-label={`${label} (opens in new tab)`}
             >
               <Icon className="h-4 w-4" />
               <span>{label}</span>
             </a>
           ))}
+          </div>
         </div>
       </div>
     </div>
@@ -1653,7 +1648,7 @@ export default function HenryKacikSite() {
   useEffect(() => { mainRef.current?.focus?.(); }, [renderRoute]);
   const onSeeWork = useCallback(() => go("portfolio"), [go]);
   return (
-    <div className="min-h-screen bg-black text-white" style={{ fontFamily: 'Inter, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans, Ubuntu, Cantarell, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji"' }}>
+    <div className="min-h-screen bg-black text-white" style={{ fontFamily: 'Jost, Futura, "Century Gothic", system-ui, sans-serif' }}>
       <a href="#main" className="sr-only focus:not-sr-only fixed top-2 left-2 z-[1000] bg-white text-black px-3 py-2 rounded">
   Skip to content
 </a>

--- a/src/index.css
+++ b/src/index.css
@@ -25,70 +25,39 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 .stained-gallery {
   position: relative;
   isolation: isolate;
-  border-radius: 1.75rem;
-  padding: clamp(0.65rem, 1.4vw, 1.1rem);
-  background:
-    radial-gradient(circle at 12% 0%, rgba(251, 191, 36, 0.12), transparent 22rem),
-    radial-gradient(circle at 88% 8%, rgba(96, 165, 250, 0.10), transparent 22rem),
-    linear-gradient(145deg, rgba(255,255,255,0.08), rgba(255,255,255,0.025));
-  box-shadow: 0 1.5rem 4.5rem rgba(0, 0, 0, 0.48), inset 0 0 0 1px rgba(255,255,255,0.10);
-}
-
-.stained-gallery::before {
-  content: "";
-  position: absolute;
-  inset: 0.5rem;
-  z-index: -1;
-  border-radius: 1.25rem;
-  background: linear-gradient(135deg, rgba(255,255,255,0.08), transparent 45%, rgba(255,255,255,0.04));
-  pointer-events: none;
-}
-
-.stained-gallery__lead {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin: 0 0 0.7rem 0.2rem;
-  color: rgba(255,255,255,0.72);
-  font-size: 0.72rem;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
+  padding: clamp(0.3rem, 0.7vw, 0.55rem);
+  background: #eee;
 }
 
 .stained-gallery__grid {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
   grid-auto-flow: dense;
-  grid-auto-rows: clamp(4.4rem, 7.2vw, 6.5rem);
-  gap: clamp(0.35rem, 0.7vw, 0.6rem);
+  grid-auto-rows: clamp(3.8rem, 6.6vw, 6rem);
+  gap: clamp(0.25rem, 0.5vw, 0.45rem);
 }
 
 .stained-pane {
   position: relative;
   display: block;
   width: 100%;
-  grid-column: span 3;
+  grid-column: span 2;
   grid-row: span 2;
   overflow: hidden;
   color: white;
   background: #050505;
   border: 0;
-  border-radius: clamp(0.8rem, 1.6vw, 1.2rem);
-  box-shadow: 0 0.85rem 2.2rem rgba(0,0,0,0.35), inset 0 0 0 1px rgba(255,255,255,0.12);
+  border-radius: 0;
+  box-shadow: none;
   transform: translateZ(0);
-  transition: transform 420ms cubic-bezier(.2,.8,.2,1), filter 420ms ease, box-shadow 420ms ease, border-radius 420ms ease;
+  transition: filter 650ms ease, opacity 650ms ease;
 }
 
-.stained-pane:nth-child(6n + 2),
-.stained-pane:nth-child(6n + 5) { grid-column: span 4; }
-.stained-pane:nth-child(6n + 3) { grid-column: span 5; }
-.stained-pane:nth-child(6n + 4) { grid-row: span 3; }
 .stained-pane.is-active {
   z-index: 4;
-  grid-column: span 8;
+  grid-column: span 9;
   grid-row: span 5;
-  border-radius: clamp(1rem, 2vw, 1.5rem);
-  box-shadow: 0 2rem 4rem rgba(0,0,0,0.58), 0 0 0 1px rgba(255,255,255,0.28);
+  box-shadow: none;
 }
 
 .stained-pane img {
@@ -96,125 +65,66 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   width: 100%;
   height: 100%;
   object-fit: cover;
-  filter: saturate(1.08) contrast(1.04) brightness(0.94);
-  transition: transform 420ms cubic-bezier(.2,.8,.2,1), filter 260ms ease;
+  filter: saturate(0.9) contrast(1.06) brightness(0.9);
+  transition: filter 650ms ease;
 }
 
-.stained-pane.is-active img { object-fit: contain; transform: scale(0.965); }
-
-.stained-pane::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: linear-gradient(180deg, transparent 45%, rgba(0,0,0,0.74));
-  opacity: 0.78;
-  transition: opacity 260ms ease;
-}
-
-.stained-pane__shine {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: radial-gradient(circle at 20% 10%, rgba(255,255,255,0.20), transparent 36%);
-  opacity: 0;
-  transition: opacity 260ms ease;
-}
-
-.stained-pane__caption {
-  position: absolute;
-  inset-inline: 0.75rem;
-  bottom: 0.75rem;
-  display: grid;
-  gap: 0.25rem;
-  padding: 0;
-  text-align: left;
-  transform: translateY(calc(100% - 1.35rem));
-  transition: transform 260ms ease;
-}
-
-.stained-pane__kicker {
-  font-size: 0.66rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: rgba(255,255,255,0.78);
-  text-shadow: 0 1px 8px rgba(0,0,0,0.65);
-}
-
-.stained-pane__text {
-  display: -webkit-box;
-  overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 2;
-  font-size: 0.84rem;
-  line-height: 1.35;
-  color: rgba(255,255,255,0.9);
-  text-shadow: 0 1px 10px rgba(0,0,0,0.8);
-}
-
-.stained-pane__expand {
-  position: absolute;
-  top: 0.85rem;
-  right: 0.85rem;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.55rem 0.75rem;
-  border: 1px solid rgba(255,255,255,0.45);
-  border-radius: 999px;
-  background: rgba(0,0,0,0.62);
-  backdrop-filter: blur(10px);
-  font-size: 0.68rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
+.stained-pane.is-active img { filter: saturate(0.96) contrast(1.08) brightness(0.98); }
 
 .stained-gallery__grid:has(.stained-pane:hover) .stained-pane:not(:hover) {
-  filter: brightness(0.78) saturate(0.88);
+  filter: brightness(0.58) saturate(0.65);
+  opacity: 0.86;
 }
 
 .stained-pane:hover,
 .stained-pane:focus-visible {
   z-index: 3;
-  transform: translateY(-0.25rem) scale(1.018);
   outline: none;
-  box-shadow: 0 1.4rem 3rem rgba(0,0,0,0.54), 0 0 0 1px rgba(255,255,255,0.24);
+  box-shadow: none;
 }
 
 .stained-pane:hover img,
 .stained-pane:focus-visible img {
-  filter: saturate(1.2) contrast(1.08) brightness(1.02);
-  transform: scale(1.045);
+  filter: saturate(0.96) contrast(1.08) brightness(0.98);
 }
-
-.stained-pane:hover::before,
-.stained-pane:focus-visible::before { opacity: 0.92; }
-.stained-pane:hover .stained-pane__shine,
-.stained-pane:focus-visible .stained-pane__shine { opacity: 1; }
-.stained-pane:hover .stained-pane__caption,
-.stained-pane:focus-visible .stained-pane__caption { transform: translateY(0); }
 
 @media (max-width: 900px) {
   .stained-gallery__grid { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-  .stained-pane { grid-column: span 4; }
-  .stained-pane:nth-child(n) { grid-column: span 4; }
-  .stained-pane.is-active { grid-column: span 8; grid-row: span 4; }
+  .stained-pane, .stained-pane:nth-child(n) { grid-column: span 2; }
+  .stained-pane.is-active { grid-column: span 6; grid-row: span 4; }
 }
 
 @media (max-width: 640px) {
-  .stained-gallery { border-radius: 1.25rem; padding: 0.55rem; }
-  .stained-gallery__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 7rem; gap: 0.4rem; }
+  .stained-gallery { padding: 0.3rem; }
+  .stained-gallery__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 6rem; gap: 0.3rem; }
   .stained-pane,
-  .stained-pane:nth-child(n) { grid-column: span 1; grid-row: span 2; border-radius: 0.75rem; }
-  .stained-pane.is-active { grid-column: 1 / -1; grid-row: span 4; }
-  .stained-pane__caption { transform: translateY(0); }
+  .stained-pane:nth-child(n), .stained-pane.is-active { grid-column: span 1; grid-row: span 2; }
+  .stained-pane:nth-child(3n + 1) { grid-column: 1 / -1; grid-row: span 3; }
+  .stained-gallery__grid:has(.stained-pane:hover) .stained-pane:not(:hover) { filter: none; opacity: 1; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .stained-pane,
-  .stained-pane img,
-  .stained-pane__shine,
-  .stained-pane__caption { transition: none; }
+  .stained-pane img { transition: none; }
   .stained-pane:hover,
   .stained-pane:focus-visible { transform: none; }
 }
+
+/* --- contact: editorial, architectural cards --- */
+.contact-page { min-height: calc(100svh - 4rem); background: radial-gradient(circle at 85% 15%, #202020 0, #090909 30%, #000 60%); }
+.contact-eyebrow { font-size: .72rem; letter-spacing: .28em; text-transform: uppercase; color: rgba(255,255,255,.58); }
+.contact-heading { max-width: 12ch; margin-top: .7rem; font-family: "Fraunces", serif; font-size: clamp(3rem, 8vw, 6.8rem); line-height: .95; letter-spacing: -.04em; }
+.contact-intro { max-width: 36rem; margin-top: 1.5rem; font-size: clamp(1.05rem, 2vw, 1.3rem); color: rgba(255,255,255,.68); }
+.contact-grid { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 1px; margin-top: clamp(3rem, 8vw, 6rem); background: rgba(255,255,255,.18); border: 1px solid rgba(255,255,255,.18); }
+.contact-card { min-height: 12rem; padding: clamp(1.25rem, 3vw, 2rem); display: flex; flex-direction: column; align-items: flex-start; background: #080808; transition: background-color 350ms ease; }
+.contact-card:hover { background: #111; }
+.contact-card--primary { background: #e9e6df; color: #080808; }
+.contact-card--primary:hover { background: #fff; }
+.contact-icon { width: 1.25rem; height: 1.25rem; margin-bottom: auto; }
+.contact-label { margin-bottom: .55rem; font-size: .68rem; letter-spacing: .2em; text-transform: uppercase; opacity: .58; }
+.contact-link { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: .5rem; font-size: clamp(1rem, 2.2vw, 1.35rem); }
+.contact-link svg { width: 1.1rem; flex: none; }
+.contact-card--social { justify-content: flex-end; }
+.contact-social { display: inline-flex; align-items: center; gap: .45rem; padding: .55rem .8rem; border: 1px solid rgba(255,255,255,.25); font-size: .78rem; transition: color 250ms ease, background 250ms ease; }
+.contact-social:hover { color: #000; background: #fff; }
+@media (max-width: 640px) { .contact-grid { grid-template-columns: 1fr; } .contact-card { min-height: 9rem; } }


### PR DESCRIPTION
### Motivation
- Make the portfolio gallery feel more dramatic and responsive to pointer hover with a gradual, non-jarring resize that highlights the hovered pane while de-emphasizing others.
- Remove glossy/rounded visual treatments and visible thumbnail captions so images read cleaner and matte, and ensure clicking any pane opens the full image directly.
- Improve mobile usability and make the contact page visually stronger with a more geometric/Futura-like primary font.

### Description
- Reworked gallery interaction so hovering/focus sets a spotlight (`spotlightIdx`) and clicking opens the full image immediately, removing the separate “View full image” control and the top label; backdrop/Close now return to the gallery view rather than the portfolio root. (`src/App.jsx`) 
- Simplified and hardened gallery visuals in CSS by removing rounded corners, shine/glow layers and glossy transforms, increasing contrast/matte feel, adjusting grid spans and gaps, and using slower filter/opacity transitions for a gradual effect; mobile-specific grid tweaks added. (`src/index.css`) 
- Hid photo numbers/captions in the thumbnail grid (they remain available in the full image view) and removed the interactive wall label text to declutter the grid. (`src/App.jsx`, `src/index.css`) 
- Updated font injection to prefer `Jost` and set the app font stack to `Jost, Futura,

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80be15a2e0832bbf0dc1b3e8ad04a9)