### PR TITLE
Refine gallery motion, mosaic framing, and contact page styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Play, Square, Mail, Phone, MapPin, ChevronLeft, ChevronRight, Instagram, Linkedin, Music2, FileDown, Eye, Printer, CheckCircle2, X, Grid3X3, ArrowUpRight } from "lucide-react";
+import { Play, Square, ChevronLeft, ChevronRight, Instagram, Linkedin, Music2, FileDown, Eye, Printer, CheckCircle2, X, Grid3X3, ArrowUpRight } from "lucide-react";
 
 // ---- GA helper (idempotent) ----------------------------------------------
 if (typeof window !== 'undefined' && !window.__hkTrack) {
@@ -1089,7 +1089,6 @@ const ProjectCard = ({ project }) => {
 const Portfolio = () => {
   const [active, setActive] = useState(null);
   const [idx, setIdx] = useState(null);
-  const [spotlightIdx, setSpotlightIdx] = useState(0);
   const [copied, setCopied] = useState(false);
   const viewingImage = idx !== null;
   const next = useCallback(() => setIdx(i => {
@@ -1115,14 +1114,14 @@ const Portfolio = () => {
       const [base, id] = hash.split('/');
       if (base === 'portfolio' && id) {
         const p = PROJECTS.find(p => p.id === id);
-        if (p) { setActive(p); setIdx(null); setSpotlightIdx(0); }
+        if (p) { setActive(p); setIdx(null); }
       }
     };
     apply();
     window.addEventListener('hashchange', apply);
     return () => window.removeEventListener('hashchange', apply);
   }, []);
-  useEffect(()=>{ const onKey = (e)=>{ if(!active) return; if(e.key==='Escape') { viewingImage ? setIdx(null) : close(); } if(viewingImage && e.key==='ArrowRight') next(); if(viewingImage && e.key==='ArrowLeft') prev(); }; const onOpen = (e) => { if(e.detail){ setActive(e.detail); setIdx(null); setSpotlightIdx(0);} }; window.addEventListener('keydown', onKey); window.addEventListener('openGallery', onOpen); return ()=>{ window.removeEventListener('keydown', onKey); window.removeEventListener('openGallery', onOpen); }; },[active, close, next, prev, viewingImage]);
+  useEffect(()=>{ const onKey = (e)=>{ if(!active) return; if(e.key==='Escape') { viewingImage ? setIdx(null) : close(); } if(viewingImage && e.key==='ArrowRight') next(); if(viewingImage && e.key==='ArrowLeft') prev(); }; const onOpen = (e) => { if(e.detail){ setActive(e.detail); setIdx(null); } }; window.addEventListener('keydown', onKey); window.addEventListener('openGallery', onOpen); return ()=>{ window.removeEventListener('keydown', onKey); window.removeEventListener('openGallery', onOpen); }; },[active, close, next, prev, viewingImage]);
   useEffect(() => { let id = null; try { id = sessionStorage.getItem('openGalleryId'); } catch(e){} if (id) { const p = PROJECTS.find(p=>p.id===id); if (p) { setActive(p); setIdx(null); } try { sessionStorage.removeItem('openGalleryId'); } catch(e){} } }, []);
   useEffect(() => { setImgLoaded(false); setCopied(false); }, [idx, active]);
   useEffect(() => {
@@ -1205,7 +1204,7 @@ const Portfolio = () => {
                   <div className="text-xs uppercase tracking-[0.2em] opacity-80">{active.role} — {active.year}</div>
                   <div className="text-2xl font-serif font-semibold">{active.title}</div>
                   <p className="mt-1 text-sm text-white/65">
-                    {viewingImage ? 'Use the arrows to move through the selected photo, or return to the full gallery.' : 'Choose a pane to bring it forward. The rest of the wall will reshape around it.'}
+                    {viewingImage ? 'Use the arrows to move through the selected photo, or return to the full gallery.' : 'Select any frame to see the full photograph.'}
                   </p>
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
@@ -1251,15 +1250,13 @@ const Portfolio = () => {
                     {active.photos.map((src, photoIdx) => (
                       <motion.button
                         key={src}
-                        layout
-                        transition={{ layout: { duration: 0.62, type: 'spring', bounce: 0.08 } }}
-                        onMouseEnter={() => setSpotlightIdx(photoIdx)}
-                        onFocus={() => setSpotlightIdx(photoIdx)}
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        transition={{ duration: 1.1, delay: Math.min(photoIdx * 0.07, 0.5), ease: 'easeOut' }}
                         onClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
-                        className={`stained-pane group ${spotlightIdx === photoIdx ? 'is-active' : ''}`}
+                        className="stained-pane group"
                         style={{ '--pane': photoIdx }}
-                        aria-label={`${spotlightIdx === photoIdx ? 'Featured' : 'Feature'} image ${photoIdx + 1} from ${active.title}`}
-                        aria-pressed={spotlightIdx === photoIdx}
+                        aria-label={`View image ${photoIdx + 1} from ${active.title}`}
                       >
                         <img
                           src={src}
@@ -1516,12 +1513,11 @@ const Resume = () => {
 const Contact = () => (
   <section className="contact-page py-28 px-6 bg-black text-white">
     <div className="mx-auto max-w-5xl">
-      <p className="contact-eyebrow">Let’s make something memorable</p>
-      <h1 className="contact-heading">Have a stage in mind?</h1>
-      <p className="contact-intro">New projects, assisting, tours, concerts — I’d love to hear what you’re creating.</p>
+      <p className="contact-eyebrow">Contact / New York</p>
+      <h1 className="contact-heading">Get in touch.</h1>
+      <p className="contact-intro">Available for lighting design, associate and assistant design, concerts, and live events.</p>
       <div className="contact-grid">
-        <div className="contact-card contact-card--primary">
-          <Mail className="contact-icon" aria-hidden="true"/>
+        <div className="contact-card">
           <span className="contact-label">Email</span>
           <a
             href={`mailto:${LINKS.email}`}
@@ -1530,7 +1526,6 @@ const Contact = () => (
           >{LINKS.email}<ArrowUpRight aria-hidden="true" /></a>
         </div>
         <div className="contact-card">
-          <Phone className="contact-icon" aria-hidden="true"/>
           <span className="contact-label">Phone</span>
           <a
             href={`tel:${LINKS.phone.replace(/[^+\d]/g,'')}`}
@@ -1539,7 +1534,6 @@ const Contact = () => (
           >{LINKS.phone}<ArrowUpRight aria-hidden="true" /></a>
         </div>
         <div className="contact-card">
-          <MapPin className="contact-icon" aria-hidden="true"/>
           <span className="contact-label">Based in</span>
           <span className="contact-link">{LINKS.location}</span>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -25,24 +25,25 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 .stained-gallery {
   position: relative;
   isolation: isolate;
-  padding: clamp(0.3rem, 0.7vw, 0.55rem);
-  background: #eee;
+  padding: clamp(0.35rem, 0.7vw, 0.6rem);
+  background: #050505;
+  overflow: hidden;
 }
 
 .stained-gallery__grid {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
   grid-auto-flow: dense;
-  grid-auto-rows: clamp(3.8rem, 6.6vw, 6rem);
-  gap: clamp(0.25rem, 0.5vw, 0.45rem);
+  grid-auto-rows: clamp(4.5rem, 7vw, 6.5rem);
+  gap: clamp(0.12rem, 0.24vw, 0.22rem);
 }
 
 .stained-pane {
   position: relative;
   display: block;
   width: 100%;
-  grid-column: span 2;
-  grid-row: span 2;
+  grid-column: span 3;
+  grid-row: span 3;
   overflow: hidden;
   color: white;
   background: #050505;
@@ -50,15 +51,14 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   border-radius: 0;
   box-shadow: none;
   transform: translateZ(0);
-  transition: filter 650ms ease, opacity 650ms ease;
+  clip-path: polygon(4% 2%, 98% 0, 94% 96%, 0 100%);
+  transition: filter 1.1s ease, opacity 1.1s ease, transform 1.1s cubic-bezier(.2,.75,.2,1);
 }
-
-.stained-pane.is-active {
-  z-index: 4;
-  grid-column: span 9;
-  grid-row: span 5;
-  box-shadow: none;
-}
+.stained-pane:nth-child(6n + 2) { grid-column: span 5; grid-row: span 3; clip-path: polygon(0 7%, 96% 0, 100% 91%, 5% 100%); }
+.stained-pane:nth-child(6n + 3) { grid-column: span 4; grid-row: span 4; clip-path: polygon(8% 0, 100% 5%, 91% 100%, 0 93%); }
+.stained-pane:nth-child(6n + 4) { grid-column: span 5; grid-row: span 4; clip-path: polygon(0 3%, 93% 0, 100% 96%, 7% 100%); }
+.stained-pane:nth-child(6n + 5) { grid-column: span 3; grid-row: span 3; clip-path: polygon(7% 5%, 100% 0, 92% 100%, 0 92%); }
+.stained-pane:nth-child(6n) { grid-column: span 4; grid-row: span 3; clip-path: polygon(0 0, 96% 8%, 100% 94%, 5% 100%); }
 
 .stained-pane img {
   display: block;
@@ -69,11 +69,9 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   transition: filter 650ms ease;
 }
 
-.stained-pane.is-active img { filter: saturate(0.96) contrast(1.08) brightness(0.98); }
-
 .stained-gallery__grid:has(.stained-pane:hover) .stained-pane:not(:hover) {
-  filter: brightness(0.58) saturate(0.65);
-  opacity: 0.86;
+  filter: brightness(0.72) saturate(0.75);
+  opacity: 0.92;
 }
 
 .stained-pane:hover,
@@ -81,6 +79,7 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   z-index: 3;
   outline: none;
   box-shadow: none;
+  transform: scale(1.015);
 }
 
 .stained-pane:hover img,
@@ -90,15 +89,16 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 
 @media (max-width: 900px) {
   .stained-gallery__grid { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-  .stained-pane, .stained-pane:nth-child(n) { grid-column: span 2; }
-  .stained-pane.is-active { grid-column: span 6; grid-row: span 4; }
+  .stained-pane, .stained-pane:nth-child(n) { grid-column: span 4; grid-row: span 3; }
+  .stained-pane:nth-child(3n + 1) { grid-column: span 5; }
+  .stained-pane:nth-child(3n + 2) { grid-column: span 3; }
 }
 
 @media (max-width: 640px) {
   .stained-gallery { padding: 0.3rem; }
   .stained-gallery__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 6rem; gap: 0.3rem; }
   .stained-pane,
-  .stained-pane:nth-child(n), .stained-pane.is-active { grid-column: span 1; grid-row: span 2; }
+  .stained-pane:nth-child(n) { grid-column: span 1; grid-row: span 2; }
   .stained-pane:nth-child(3n + 1) { grid-column: 1 / -1; grid-row: span 3; }
   .stained-gallery__grid:has(.stained-pane:hover) .stained-pane:not(:hover) { filter: none; opacity: 1; }
 }
@@ -110,21 +110,18 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   .stained-pane:focus-visible { transform: none; }
 }
 
-/* --- contact: editorial, architectural cards --- */
-.contact-page { min-height: calc(100svh - 4rem); background: radial-gradient(circle at 85% 15%, #202020 0, #090909 30%, #000 60%); }
+/* --- contact: restrained editorial directory --- */
+.contact-page { min-height: calc(100svh - 4rem); background: #050505; }
 .contact-eyebrow { font-size: .72rem; letter-spacing: .28em; text-transform: uppercase; color: rgba(255,255,255,.58); }
-.contact-heading { max-width: 12ch; margin-top: .7rem; font-family: "Fraunces", serif; font-size: clamp(3rem, 8vw, 6.8rem); line-height: .95; letter-spacing: -.04em; }
+.contact-heading { max-width: 12ch; margin-top: .7rem; font-family: "Fraunces", serif; font-size: clamp(3rem, 8vw, 6.8rem); font-weight: 400; line-height: .95; letter-spacing: -.04em; }
 .contact-intro { max-width: 36rem; margin-top: 1.5rem; font-size: clamp(1.05rem, 2vw, 1.3rem); color: rgba(255,255,255,.68); }
-.contact-grid { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 1px; margin-top: clamp(3rem, 8vw, 6rem); background: rgba(255,255,255,.18); border: 1px solid rgba(255,255,255,.18); }
-.contact-card { min-height: 12rem; padding: clamp(1.25rem, 3vw, 2rem); display: flex; flex-direction: column; align-items: flex-start; background: #080808; transition: background-color 350ms ease; }
-.contact-card:hover { background: #111; }
-.contact-card--primary { background: #e9e6df; color: #080808; }
-.contact-card--primary:hover { background: #fff; }
-.contact-icon { width: 1.25rem; height: 1.25rem; margin-bottom: auto; }
-.contact-label { margin-bottom: .55rem; font-size: .68rem; letter-spacing: .2em; text-transform: uppercase; opacity: .58; }
+.contact-grid { margin-top: clamp(3rem, 8vw, 6rem); border-top: 1px solid rgba(255,255,255,.25); }
+.contact-card { min-height: 7rem; padding: 1.4rem 0; display: grid; grid-template-columns: minmax(7rem, 1fr) 3fr; align-items: center; border-bottom: 1px solid rgba(255,255,255,.18); transition: border-color 450ms ease; }
+.contact-card:hover { border-color: rgba(255,255,255,.65); }
+.contact-label { font-size: .68rem; letter-spacing: .2em; text-transform: uppercase; opacity: .58; }
 .contact-link { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: .5rem; font-size: clamp(1rem, 2.2vw, 1.35rem); }
 .contact-link svg { width: 1.1rem; flex: none; }
-.contact-card--social { justify-content: flex-end; }
+.contact-card--social { align-items: center; }
 .contact-social { display: inline-flex; align-items: center; gap: .45rem; padding: .55rem .8rem; border: 1px solid rgba(255,255,255,.25); font-size: .78rem; transition: color 250ms ease, background 250ms ease; }
 .contact-social:hover { color: #000; background: #fff; }
-@media (max-width: 640px) { .contact-grid { grid-template-columns: 1fr; } .contact-card { min-height: 9rem; } }
+@media (max-width: 640px) { .contact-card { min-height: 7rem; grid-template-columns: 1fr; gap: 1rem; } }


### PR DESCRIPTION
### Motivation
- Make the portfolio gallery feel less disorienting and slower-paced with smoother, more cinematic transitions and interesting dynamic frame shapes. 
- Reduce empty white space during layout changes and bring the contact page into a more restrained, consistent editorial aesthetic.

### Description
- Update gallery visuals and motion by adding polygonal `clip-path` frames, darker background, altered grid sizing/gaps, and piecewise pane dimensions in `src/index.css` to create a dense, asymmetric mosaic. 
- Replace the fast layout-shuffle / spotlight behavior with gentle per-pane fade-in animation and slower hover transforms by removing the `spotlightIdx` state and adding `initial`/`animate` transitions to the gallery buttons in `src/App.jsx`. 
- Simplify gallery microcopy to clarify interactions (changed gallery instruction text) and keep selection labels accessible (changed aria labels to `View image …`).
- Redesign the contact area for a restrained editorial directory tone by changing copy and card layout in `src/App.jsx` and styling in `src/index.css`, and remove unused decorative icon imports from `lucide-react`.
- Files changed: `src/App.jsx`, `src/index.css` (commit message: `Refine gallery motion and contact styling`).

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran a site health check with `curl http://127.0.0.1:5173/#portfolio` which returned HTTP `200`. 
- Ran `git diff --check` and `git status` with a clean working tree after committing the changes. 
- Attempted browser automation screenshot capture but Chromium / Playwright was not available in the environment, so visual regression snapshots were not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80c1446488832b8127a2dca3e5c063)