### PR TITLE
Create a tighter, smoothly interactive gallery mosaic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1108,6 +1108,13 @@ const Portfolio = () => {
   }, []);
   const [imgLoaded, setImgLoaded] = useState(false);
   const currentSrc = viewingImage && active?.photos ? active.photos[idx] : null;
+  const galleryRows = useMemo(() => {
+    if (!active?.photos) return [];
+    const rowCount = active.photos.length > 11 ? 3 : 2;
+    const rows = Array.from({ length: rowCount }, () => []);
+    active.photos.forEach((src, photoIdx) => rows[photoIdx % rowCount].push({ src, photoIdx }));
+    return rows;
+  }, [active]);
   useEffect(() => {
     const apply = () => {
       const hash = window.location.hash.slice(1);       // e.g., "portfolio/great-comet-2024"
@@ -1247,24 +1254,28 @@ const Portfolio = () => {
                   style={{ '--pane-count': active.photos.length }}
                 >
                   <div className="stained-gallery__grid">
-                    {active.photos.map((src, photoIdx) => (
-                      <motion.button
-                        key={src}
-                        initial={{ opacity: 0 }}
-                        animate={{ opacity: 1 }}
-                        transition={{ duration: 1.1, delay: Math.min(photoIdx * 0.07, 0.5), ease: 'easeOut' }}
-                        onClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
-                        className="stained-pane group"
-                        style={{ '--pane': photoIdx }}
-                        aria-label={`View image ${photoIdx + 1} from ${active.title}`}
-                      >
-                        <img
-                          src={src}
-                          alt={active.captions?.[photoIdx] || `${active.title} production photo ${photoIdx + 1}`}
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      </motion.button>
+                    {galleryRows.map((row, rowIdx) => (
+                      <div className="stained-gallery__row" key={rowIdx}>
+                        {row.map(({ src, photoIdx }, paneIdx) => (
+                          <motion.button
+                            key={src}
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            transition={{ duration: 0.9, delay: Math.min(photoIdx * 0.055, 0.45), ease: 'easeOut' }}
+                            onClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
+                            className="stained-pane group"
+                            style={{ '--pane': paneIdx, '--row': rowIdx }}
+                            aria-label={`View image ${photoIdx + 1} from ${active.title}`}
+                          >
+                            <img
+                              src={src}
+                              alt={active.captions?.[photoIdx] || `${active.title} production photo ${photoIdx + 1}`}
+                              loading="lazy"
+                              decoding="async"
+                            />
+                          </motion.button>
+                        ))}
+                      </div>
                     ))}
                   </div>
                 </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -25,25 +25,32 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 .stained-gallery {
   position: relative;
   isolation: isolate;
-  padding: clamp(0.35rem, 0.7vw, 0.6rem);
+  padding: clamp(0.2rem, 0.4vw, 0.35rem);
   background: #050505;
   overflow: hidden;
 }
 
 .stained-gallery__grid {
-  display: grid;
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-  grid-auto-flow: dense;
-  grid-auto-rows: clamp(4.5rem, 7vw, 6.5rem);
-  gap: clamp(0.12rem, 0.24vw, 0.22rem);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  overflow: hidden;
+}
+
+.stained-gallery__row {
+  display: flex;
+  width: calc(100% + 2.5rem);
+  min-height: clamp(10rem, 21vw, 15rem);
+  margin-inline: -1.25rem;
+  gap: 3px;
+  overflow: hidden;
 }
 
 .stained-pane {
   position: relative;
   display: block;
-  width: 100%;
-  grid-column: span 3;
-  grid-row: span 3;
+  flex: 1 1 0;
+  min-width: 0;
   overflow: hidden;
   color: white;
   background: #050505;
@@ -51,14 +58,14 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   border-radius: 0;
   box-shadow: none;
   transform: translateZ(0);
-  clip-path: polygon(4% 2%, 98% 0, 94% 96%, 0 100%);
-  transition: filter 1.1s ease, opacity 1.1s ease, transform 1.1s cubic-bezier(.2,.75,.2,1);
+  clip-path: polygon(8% 0, 100% 0, 92% 100%, 0 100%);
+  transition: flex-grow 900ms cubic-bezier(.2,.72,.16,1), filter 700ms ease, opacity 700ms ease, transform 900ms cubic-bezier(.2,.72,.16,1);
 }
-.stained-pane:nth-child(6n + 2) { grid-column: span 5; grid-row: span 3; clip-path: polygon(0 7%, 96% 0, 100% 91%, 5% 100%); }
-.stained-pane:nth-child(6n + 3) { grid-column: span 4; grid-row: span 4; clip-path: polygon(8% 0, 100% 5%, 91% 100%, 0 93%); }
-.stained-pane:nth-child(6n + 4) { grid-column: span 5; grid-row: span 4; clip-path: polygon(0 3%, 93% 0, 100% 96%, 7% 100%); }
-.stained-pane:nth-child(6n + 5) { grid-column: span 3; grid-row: span 3; clip-path: polygon(7% 5%, 100% 0, 92% 100%, 0 92%); }
-.stained-pane:nth-child(6n) { grid-column: span 4; grid-row: span 3; clip-path: polygon(0 0, 96% 8%, 100% 94%, 5% 100%); }
+.stained-pane + .stained-pane { margin-left: clamp(-3rem, -3.6vw, -1.35rem); }
+.stained-gallery__row:nth-child(even) { transform: translateX(-1.25rem); }
+.stained-gallery__row:nth-child(even) .stained-pane { clip-path: polygon(0 0, 92% 0, 100% 100%, 8% 100%); }
+.stained-pane:nth-child(3n + 2) { clip-path: polygon(0 0, 100% 0, 91% 100%, 9% 100%); }
+.stained-gallery__row:nth-child(even) .stained-pane:nth-child(3n + 2) { clip-path: polygon(9% 0, 91% 0, 100% 100%, 0 100%); }
 
 .stained-pane img {
   display: block;
@@ -69,9 +76,10 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   transition: filter 650ms ease;
 }
 
-.stained-gallery__grid:has(.stained-pane:hover) .stained-pane:not(:hover) {
+.stained-gallery__grid:has(.stained-pane:is(:hover, :focus-visible)) .stained-pane:not(:hover):not(:focus-visible) {
+  flex-grow: .78;
   filter: brightness(0.72) saturate(0.75);
-  opacity: 0.92;
+  opacity: 0.82;
 }
 
 .stained-pane:hover,
@@ -79,7 +87,8 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   z-index: 3;
   outline: none;
   box-shadow: none;
-  transform: scale(1.015);
+  flex-grow: 2.15;
+  transform: scale(1.008);
 }
 
 .stained-pane:hover img,
@@ -88,19 +97,15 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 }
 
 @media (max-width: 900px) {
-  .stained-gallery__grid { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-  .stained-pane, .stained-pane:nth-child(n) { grid-column: span 4; grid-row: span 3; }
-  .stained-pane:nth-child(3n + 1) { grid-column: span 5; }
-  .stained-pane:nth-child(3n + 2) { grid-column: span 3; }
+  .stained-gallery__row { min-height: clamp(9rem, 27vw, 13rem); }
 }
 
 @media (max-width: 640px) {
-  .stained-gallery { padding: 0.3rem; }
-  .stained-gallery__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 6rem; gap: 0.3rem; }
-  .stained-pane,
-  .stained-pane:nth-child(n) { grid-column: span 1; grid-row: span 2; }
-  .stained-pane:nth-child(3n + 1) { grid-column: 1 / -1; grid-row: span 3; }
-  .stained-gallery__grid:has(.stained-pane:hover) .stained-pane:not(:hover) { filter: none; opacity: 1; }
+  .stained-gallery { padding: 0.2rem; }
+  .stained-gallery__row { width: calc(100% + 1.25rem); min-height: 9rem; margin-inline: -0.625rem; }
+  .stained-pane + .stained-pane { margin-left: -1.15rem; }
+  .stained-gallery__row:nth-child(even) { transform: translateX(-0.625rem); }
+  .stained-gallery__grid:has(.stained-pane:is(:hover, :focus-visible)) .stained-pane:not(:hover):not(:focus-visible) { filter: brightness(.78); opacity: .86; }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
### Motivation
- The portfolio gallery looked visually disjointed with large gaps between image angles and lacked a cohesive, fluid interaction for highlighting a featured image.
- The goal was to present images as a compact, interlocking mosaic where the focused pane grows while neighbors smoothly recede for a polished visual experience.
- Accessibility and existing behaviors such as keyboard navigation, lightbox details, and reduced-motion preference needed to be preserved.

### Description
- Group gallery photos into 2 or 3 interlocking rows via a new `galleryRows` `useMemo` in `src/App.jsx` to preserve original indices while producing compact mosaic rows. 
- Replace the previous grid rendering with row wrappers (`.stained-gallery__row`) and render panes inside each row in `src/App.jsx` to enable overlapping, staggered layout and staggered entrance timing. 
- Rework gallery CSS in `src/index.css` to move from a grid to a stacked row flex layout, add negative inter-pane margins and alternating row offsets, update polygon `clip-path`s, and introduce `flex-grow` based transitions so the hovered/focused pane expands while adjacent panes shrink, darken, and desaturate. 
- Add responsive sizing tweaks and maintain reduced-motion support and existing keyboard/lightbox behaviors, while slightly tightening outer paddings for a denser mosaic.

### Testing
- Ran `npm run build` which completed successfully (build succeeded though the bundle emitted size warnings about large chunks). 
- Ran `git diff --check` which returned clean results. 
- Verified repository state with `git status --short --branch` and committed the change as `Refine gallery mosaic interactions`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80e171adb8832b815c17886572b241)