### PR TITLE
Refine gallery motion and loading performance

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -809,7 +809,7 @@ const ParticleHero = ({ imageUrl, onReady, onError }) => {
   const containerRef = useRef(null);
   const rendererRef = useRef(null);
   const animRef = useRef(null);
-  const mouseRef = useRef({ brush: 0, target: 0 });
+  const mouseRef = useRef({ brush: 0, target: 0, x: 0.5, y: 0.5, targetX: 0.5, targetY: 0.5 });
   const inViewRef = useRef(true);
 
   useEffect(() => {
@@ -837,10 +837,10 @@ const ParticleHero = ({ imageUrl, onReady, onError }) => {
         const container = containerRef.current;
         if (!container) return;
 
-        const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+        const renderer = new THREE.WebGLRenderer({ antialias: false, alpha: true, powerPreference: 'high-performance' });
         renderer.outputColorSpace = THREE.SRGBColorSpace;
         renderer.setClearColor(0x000000, 0);
-        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+        renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.35));
         renderer.setSize(container.clientWidth, container.clientHeight, true);
         Object.assign(renderer.domElement.style, { width: '100%', height: '100%', display: 'block' });
         rendererRef.current = renderer;
@@ -953,7 +953,7 @@ const ParticleHero = ({ imageUrl, onReady, onError }) => {
         const onResize = () => {
           const w = container.clientWidth, h = container.clientHeight;
           renderer.setSize(w, h, true);
-          renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+          renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.35));
           uniforms.u_res.value.set(w, h);
         };
         onResize();
@@ -965,8 +965,9 @@ const ParticleHero = ({ imageUrl, onReady, onError }) => {
           if (inside) {
             const x = (e.clientX - rect.left) / rect.width;
             const y = 1.0 - (e.clientY - rect.top) / rect.height;
-            uniforms.u_mouse.value.set(x, y);
-            mouseRef.current.target = Math.min(1, mouseRef.current.target + 0.08);
+            mouseRef.current.targetX = x;
+            mouseRef.current.targetY = y;
+            mouseRef.current.target = 0.72;
           } else {
             mouseRef.current.target = 0;
           }
@@ -982,7 +983,11 @@ const ParticleHero = ({ imageUrl, onReady, onError }) => {
           if (inViewRef.current) {
             uniforms.u_time.value = (performance.now() - start) / 1000;
             const m = mouseRef.current;
-            m.brush += (m.target - m.brush) * 0.1;
+            // A deliberately slow spring removes the hard cursor-following edge.
+            m.x += (m.targetX - m.x) * 0.035;
+            m.y += (m.targetY - m.y) * 0.035;
+            m.brush += (m.target - m.brush) * 0.028;
+            uniforms.u_mouse.value.set(m.x, m.y);
             uniforms.u_brush.value = m.brush;
             renderer.render(scene, camera);
           }
@@ -1043,7 +1048,7 @@ const ProjectCard = ({ project }) => {
   const [ratioStr, setRatioStr] = useState('16 / 9');
   const open = useCallback(() => { const ev = new CustomEvent('openGallery', { detail: project }); window.dispatchEvent(ev); }, [project]);
   return (
-    <div ref={ref} className="relative flex flex-col md:grid md:grid-cols-12">
+    <div ref={ref} className="portfolio-project relative flex flex-col md:grid md:grid-cols-12">
      <div
   className="md:col-span-8 overflow-hidden group relative bg-black"
   style={{ aspectRatio: ratioStr }}
@@ -1059,7 +1064,7 @@ const ProjectCard = ({ project }) => {
       style={{ objectFit: 'contain', objectPosition: 'center' }}
       loading="lazy"
       decoding="async"
-        fetchpriority="high"
+      fetchpriority="low"
       sizes="(min-width: 1024px) 66vw, 100vw"
       onLoad={(e) => {
         const w = e.target.naturalWidth || 16;
@@ -1272,6 +1277,8 @@ const Portfolio = () => {
                               alt={active.captions?.[photoIdx] || `${active.title} production photo ${photoIdx + 1}`}
                               loading="lazy"
                               decoding="async"
+                              fetchpriority={photoIdx < 2 ? "high" : "low"}
+                              sizes="(min-width: 900px) 34vw, 55vw"
                             />
                           </motion.button>
                         ))}
@@ -1330,9 +1337,9 @@ const About = ({ onNavigate }) => (
           src={ABOUT.photo}
           alt="Headshot of Henry Kacik"
           className="w-full h-auto block"
-          loading="eager"
+          loading="lazy"
           decoding="async"
-          fetchpriority="high"
+          fetchpriority="low"
           sizes="(min-width: 768px) 40vw, 90vw"
         />
         <figcaption className="sr-only">Brooklyn-based lighting designer, theatre/concerts/events.</figcaption>

--- a/src/index.css
+++ b/src/index.css
@@ -26,14 +26,15 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   position: relative;
   isolation: isolate;
   padding: clamp(0.2rem, 0.4vw, 0.35rem);
-  background: #050505;
+  background: rgba(255, 255, 255, 0.92);
   overflow: hidden;
 }
 
 .stained-gallery__grid {
   display: flex;
   flex-direction: column;
-  gap: 3px;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.92);
   overflow: hidden;
 }
 
@@ -42,14 +43,14 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   width: calc(100% + 2.5rem);
   min-height: clamp(10rem, 21vw, 15rem);
   margin-inline: -1.25rem;
-  gap: 3px;
+  gap: 4px;
   overflow: hidden;
 }
 
 .stained-pane {
   position: relative;
   display: block;
-  flex: 1 1 0;
+  flex: var(--pane-weight, 1) 1 0;
   min-width: 0;
   overflow: hidden;
   color: white;
@@ -59,13 +60,14 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   box-shadow: none;
   transform: translateZ(0);
   clip-path: polygon(8% 0, 100% 0, 92% 100%, 0 100%);
-  transition: flex-grow 900ms cubic-bezier(.2,.72,.16,1), filter 700ms ease, opacity 700ms ease, transform 900ms cubic-bezier(.2,.72,.16,1);
+  transition: filter 1200ms cubic-bezier(.16,1,.3,1), opacity 1200ms cubic-bezier(.16,1,.3,1), transform 1400ms cubic-bezier(.16,1,.3,1);
 }
-.stained-pane + .stained-pane { margin-left: clamp(-3rem, -3.6vw, -1.35rem); }
+.stained-pane:nth-child(4n + 1) { --pane-weight: 1.18; clip-path: polygon(0 0, 100% 7%, 88% 100%, 7% 92%); }
+.stained-pane:nth-child(4n + 2) { --pane-weight: .82; clip-path: polygon(11% 3%, 100% 0, 94% 91%, 0 100%); }
+.stained-pane:nth-child(4n + 3) { --pane-weight: 1.35; clip-path: polygon(5% 0, 94% 8%, 100% 100%, 0 91%); }
+.stained-pane:nth-child(4n) { --pane-weight: .95; clip-path: polygon(0 8%, 100% 0, 91% 100%, 8% 94%); }
 .stained-gallery__row:nth-child(even) { transform: translateX(-1.25rem); }
-.stained-gallery__row:nth-child(even) .stained-pane { clip-path: polygon(0 0, 92% 0, 100% 100%, 8% 100%); }
-.stained-pane:nth-child(3n + 2) { clip-path: polygon(0 0, 100% 0, 91% 100%, 9% 100%); }
-.stained-gallery__row:nth-child(even) .stained-pane:nth-child(3n + 2) { clip-path: polygon(9% 0, 91% 0, 100% 100%, 0 100%); }
+.stained-gallery__row:nth-child(2) { min-height: clamp(12rem, 24vw, 17rem); }
 
 .stained-pane img {
   display: block;
@@ -73,13 +75,13 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   height: 100%;
   object-fit: cover;
   filter: saturate(0.9) contrast(1.06) brightness(0.9);
-  transition: filter 650ms ease;
+  transform: scale(1.025);
+  transition: filter 1300ms cubic-bezier(.16,1,.3,1), transform 1800ms cubic-bezier(.16,1,.3,1);
 }
 
 .stained-gallery__grid:has(.stained-pane:is(:hover, :focus-visible)) .stained-pane:not(:hover):not(:focus-visible) {
-  flex-grow: .78;
-  filter: brightness(0.72) saturate(0.75);
-  opacity: 0.82;
+  filter: brightness(0.88) saturate(0.86);
+  opacity: 0.94;
 }
 
 .stained-pane:hover,
@@ -87,14 +89,17 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   z-index: 3;
   outline: none;
   box-shadow: none;
-  flex-grow: 2.15;
-  transform: scale(1.008);
+  transform: scale(1.004);
 }
 
 .stained-pane:hover img,
 .stained-pane:focus-visible img {
   filter: saturate(0.96) contrast(1.08) brightness(0.98);
+  transform: scale(1.055);
 }
+
+/* Keep off-screen portfolio sections out of the initial layout/paint budget. */
+.portfolio-project { content-visibility: auto; contain-intrinsic-size: auto 760px; }
 
 @media (max-width: 900px) {
   .stained-gallery__row { min-height: clamp(9rem, 27vw, 13rem); }
@@ -103,7 +108,6 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 @media (max-width: 640px) {
   .stained-gallery { padding: 0.2rem; }
   .stained-gallery__row { width: calc(100% + 1.25rem); min-height: 9rem; margin-inline: -0.625rem; }
-  .stained-pane + .stained-pane { margin-left: -1.15rem; }
   .stained-gallery__row:nth-child(even) { transform: translateX(-0.625rem); }
   .stained-gallery__grid:has(.stained-pane:is(:hover, :focus-visible)) .stained-pane:not(:hover):not(:focus-visible) { filter: brightness(.78); opacity: .86; }
 }


### PR DESCRIPTION
### Motivation

- Make the portfolio gallery feel smooth and subtle (less jumpy when the cursor moves) while adding more expressive, varied pane shapes for a more creative mosaic look.
- Reduce GPU/paint overhead and improve perceived load times by deferring and lowering priority for non-critical images and off-screen content.

### Description

- Tweak gallery styling in `src/index.css` to use varied pane widths via `--pane-weight` and new `clip-path`s, increase spacing, slow and soften transitions, reduce hover amplification, and add `content-visibility` for off-screen `.portfolio-project` elements.
- Smooth the hero particle cursor by introducing `mouseRef.x/y` and `targetX/targetY`, applying a slow interpolation spring, lowering brush lerp, and using the interpolated position for `u_mouse` in `src/App.jsx` for gentler follow behavior.
- Reduce WebGL cost by disabling antialiasing and setting `powerPreference: 'high-performance'` and capping `renderer.setPixelRatio` to `1.35` so the Three.js effect renders more cheaply on constrained devices in `src/App.jsx` while keeping capability gating for Three imports.
- Improve loading priorities in `src/App.jsx` by lowering `fetchpriority` for heavy images and the About headshot to `low`, and selectively keeping `high` priority only for the first gallery frames; add responsive `sizes` hints to better guide the browser.

### Testing

- Ran `git diff --check` which reported no issues and succeeded. ✅
- Ran a full production build with `npm run build`; the build completed successfully (bundle produced) though Rollup emitted large-chunk warnings for `three` which remain informational. ✅
- Attempted to capture a browser screenshot but no browser executable was available in the environment, so no runtime UI screenshot was produced. ⚠️
- Attempted to run the local `make_pr` helper but it failed because a required Python package (`mcp`) was not present in the environment, so automated PR tooling could not be exercised here. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80e7b06b08832b99a01fec4ab4fefd)