### PR TITLE
Redesign portfolio gallery as a polished stained-glass mosaic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1113,13 +1113,6 @@ const Portfolio = () => {
   }, []);
   const [imgLoaded, setImgLoaded] = useState(false);
   const currentSrc = viewingImage && active?.photos ? active.photos[idx] : null;
-  const galleryRows = useMemo(() => {
-    if (!active?.photos) return [];
-    const rowCount = active.photos.length > 11 ? 3 : 2;
-    const rows = Array.from({ length: rowCount }, () => []);
-    active.photos.forEach((src, photoIdx) => rows[photoIdx % rowCount].push({ src, photoIdx }));
-    return rows;
-  }, [active]);
   useEffect(() => {
     const apply = () => {
       const hash = window.location.hash.slice(1);       // e.g., "portfolio/great-comet-2024"
@@ -1259,30 +1252,26 @@ const Portfolio = () => {
                   style={{ '--pane-count': active.photos.length }}
                 >
                   <div className="stained-gallery__grid">
-                    {galleryRows.map((row, rowIdx) => (
-                      <div className="stained-gallery__row" key={rowIdx}>
-                        {row.map(({ src, photoIdx }, paneIdx) => (
-                          <motion.button
-                            key={src}
-                            initial={{ opacity: 0 }}
-                            animate={{ opacity: 1 }}
-                            transition={{ duration: 0.9, delay: Math.min(photoIdx * 0.055, 0.45), ease: 'easeOut' }}
-                            onClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
-                            className="stained-pane group"
-                            style={{ '--pane': paneIdx, '--row': rowIdx }}
-                            aria-label={`View image ${photoIdx + 1} from ${active.title}`}
-                          >
-                            <img
-                              src={src}
-                              alt={active.captions?.[photoIdx] || `${active.title} production photo ${photoIdx + 1}`}
-                              loading="lazy"
-                              decoding="async"
-                              fetchpriority={photoIdx < 2 ? "high" : "low"}
-                              sizes="(min-width: 900px) 34vw, 55vw"
-                            />
-                          </motion.button>
-                        ))}
-                      </div>
+                    {active.photos.map((src, photoIdx) => (
+                      <motion.button
+                        key={src}
+                        initial={{ opacity: 0, scale: 0.985 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        transition={{ duration: 0.7, delay: Math.min(photoIdx * 0.045, 0.4), ease: [0.16, 1, 0.3, 1] }}
+                        onClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
+                        className="stained-pane group"
+                        aria-label={`View image ${photoIdx + 1} from ${active.title}`}
+                      >
+                        <img
+                          src={src}
+                          alt={active.captions?.[photoIdx] || `${active.title} production photo ${photoIdx + 1}`}
+                          loading={photoIdx < 4 ? "eager" : "lazy"}
+                          decoding="async"
+                          fetchpriority={photoIdx < 2 ? "high" : "low"}
+                          sizes="(min-width: 900px) 38vw, (min-width: 640px) 50vw, 100vw"
+                        />
+                        <span className="stained-pane__number" aria-hidden="true">{String(photoIdx + 1).padStart(2, '0')}</span>
+                      </motion.button>
                     ))}
                   </div>
                 </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -21,95 +21,124 @@ img, video, canvas {
 img[data-fit="cover"]   { width: 100%; height: 100%; object-fit: cover;  object-position: center; }
 img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object-position: center; }
 
-/* --- portfolio gallery: responsive, shifting pane wall --- */
+/* --- portfolio gallery: an architectural wall of illuminated panes --- */
 .stained-gallery {
   position: relative;
   isolation: isolate;
-  padding: clamp(0.2rem, 0.4vw, 0.35rem);
-  background: rgba(255, 255, 255, 0.92);
+  padding: clamp(0.45rem, 0.8vw, 0.75rem);
+  background: #111;
+  border: 1px solid rgba(255,255,255,.2);
+  border-radius: 1.25rem;
+  box-shadow: 0 28px 80px rgba(0,0,0,.55), inset 0 0 0 1px rgba(255,255,255,.05);
   overflow: hidden;
 }
 
 .stained-gallery__grid {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  background: rgba(255, 255, 255, 0.92);
-  overflow: hidden;
-}
-
-.stained-gallery__row {
-  display: flex;
-  width: calc(100% + 2.5rem);
-  min-height: clamp(10rem, 21vw, 15rem);
-  margin-inline: -1.25rem;
-  gap: 4px;
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  grid-auto-flow: dense;
+  grid-auto-rows: clamp(3.2rem, 5.5vw, 5.2rem);
+  gap: clamp(0.35rem, 0.65vw, 0.6rem);
+  padding: clamp(0.15rem, 0.3vw, 0.25rem);
+  background: #111;
+  border-radius: .75rem;
   overflow: hidden;
 }
 
 .stained-pane {
   position: relative;
   display: block;
-  flex: var(--pane-weight, 1) 1 0;
+  width: 100%;
+  grid-column: span 3;
+  grid-row: span 3;
   min-width: 0;
   overflow: hidden;
   color: white;
-  background: #050505;
+  background: #171717;
   border: 0;
-  border-radius: 0;
-  box-shadow: none;
+  border-radius: .25rem;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.1);
   transform: translateZ(0);
-  clip-path: polygon(8% 0, 100% 0, 92% 100%, 0 100%);
-  transition: filter 1200ms cubic-bezier(.16,1,.3,1), opacity 1200ms cubic-bezier(.16,1,.3,1), transform 1400ms cubic-bezier(.16,1,.3,1);
+  transition: filter 700ms cubic-bezier(.16,1,.3,1), opacity 700ms cubic-bezier(.16,1,.3,1), transform 700ms cubic-bezier(.16,1,.3,1), box-shadow 700ms cubic-bezier(.16,1,.3,1);
 }
-.stained-pane:nth-child(4n + 1) { --pane-weight: 1.18; clip-path: polygon(0 0, 100% 7%, 88% 100%, 7% 92%); }
-.stained-pane:nth-child(4n + 2) { --pane-weight: .82; clip-path: polygon(11% 3%, 100% 0, 94% 91%, 0 100%); }
-.stained-pane:nth-child(4n + 3) { --pane-weight: 1.35; clip-path: polygon(5% 0, 94% 8%, 100% 100%, 0 91%); }
-.stained-pane:nth-child(4n) { --pane-weight: .95; clip-path: polygon(0 8%, 100% 0, 91% 100%, 8% 94%); }
-.stained-gallery__row:nth-child(even) { transform: translateX(-1.25rem); }
-.stained-gallery__row:nth-child(2) { min-height: clamp(12rem, 24vw, 17rem); }
+.stained-pane:nth-child(8n + 1), .stained-pane:nth-child(8n + 6) { grid-column: span 5; grid-row: span 4; }
+.stained-pane:nth-child(8n + 2), .stained-pane:nth-child(8n + 7) { grid-column: span 4; grid-row: span 4; }
+.stained-pane:nth-child(8n + 3) { grid-column: span 3; grid-row: span 4; }
+.stained-pane:nth-child(8n + 4) { grid-column: span 4; grid-row: span 3; }
+.stained-pane:nth-child(8n + 5) { grid-column: span 3; grid-row: span 3; }
+.stained-pane:nth-child(8n) { grid-column: span 5; grid-row: span 3; }
 
 .stained-pane img {
   display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
-  filter: saturate(0.9) contrast(1.06) brightness(0.9);
-  transform: scale(1.025);
-  transition: filter 1300ms cubic-bezier(.16,1,.3,1), transform 1800ms cubic-bezier(.16,1,.3,1);
+  filter: saturate(.94) contrast(1.04) brightness(.88);
+  transform: scale(1.01);
+  transition: filter 900ms cubic-bezier(.16,1,.3,1), transform 1100ms cubic-bezier(.16,1,.3,1);
+}
+
+.stained-pane::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, transparent 55%, rgba(0,0,0,.48));
+  opacity: .65;
+  transition: opacity 500ms ease;
+}
+
+.stained-pane__number {
+  position: absolute;
+  z-index: 2;
+  right: .8rem;
+  bottom: .65rem;
+  font-size: .62rem;
+  letter-spacing: .16em;
+  color: rgba(255,255,255,.78);
+  opacity: 0;
+  transform: translateY(4px);
+  transition: opacity 400ms ease, transform 500ms cubic-bezier(.16,1,.3,1);
 }
 
 .stained-gallery__grid:has(.stained-pane:is(:hover, :focus-visible)) .stained-pane:not(:hover):not(:focus-visible) {
-  filter: brightness(0.88) saturate(0.86);
-  opacity: 0.94;
+  filter: brightness(.62) saturate(.7);
+  opacity: .8;
 }
 
 .stained-pane:hover,
 .stained-pane:focus-visible {
   z-index: 3;
   outline: none;
-  box-shadow: none;
-  transform: scale(1.004);
+  box-shadow: 0 18px 35px rgba(0,0,0,.38), inset 0 0 0 1px rgba(255,255,255,.32);
+  transform: scale(1.012);
 }
 
 .stained-pane:hover img,
 .stained-pane:focus-visible img {
-  filter: saturate(0.96) contrast(1.08) brightness(0.98);
-  transform: scale(1.055);
+  filter: saturate(1.03) contrast(1.05) brightness(1);
+  transform: scale(1.045);
 }
+.stained-pane:hover::after, .stained-pane:focus-visible::after { opacity: .35; }
+.stained-pane:hover .stained-pane__number, .stained-pane:focus-visible .stained-pane__number { opacity: 1; transform: translateY(0); }
 
 /* Keep off-screen portfolio sections out of the initial layout/paint budget. */
 .portfolio-project { content-visibility: auto; contain-intrinsic-size: auto 760px; }
 
 @media (max-width: 900px) {
-  .stained-gallery__row { min-height: clamp(9rem, 27vw, 13rem); }
+  .stained-gallery__grid { grid-template-columns: repeat(8, minmax(0, 1fr)); grid-auto-rows: clamp(3.5rem, 8vw, 5rem); }
+  .stained-pane:nth-child(n) { grid-column: span 4; grid-row: span 3; }
+  .stained-pane:nth-child(5n + 1), .stained-pane:nth-child(5n + 4) { grid-column: span 5; grid-row: span 4; }
+  .stained-pane:nth-child(5n + 2), .stained-pane:nth-child(5n + 5) { grid-column: span 3; grid-row: span 4; }
 }
 
 @media (max-width: 640px) {
-  .stained-gallery { padding: 0.2rem; }
-  .stained-gallery__row { width: calc(100% + 1.25rem); min-height: 9rem; margin-inline: -0.625rem; }
-  .stained-gallery__row:nth-child(even) { transform: translateX(-0.625rem); }
-  .stained-gallery__grid:has(.stained-pane:is(:hover, :focus-visible)) .stained-pane:not(:hover):not(:focus-visible) { filter: brightness(.78); opacity: .86; }
+  .stained-gallery { padding: .4rem; border-radius: .8rem; }
+  .stained-gallery__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 5rem; gap: .4rem; padding: 0; }
+  .stained-pane:nth-child(n) { grid-column: span 1; grid-row: span 2; }
+  .stained-pane:nth-child(4n + 1) { grid-column: 1 / -1; grid-row: span 3; }
+  .stained-gallery__grid:has(.stained-pane:is(:hover, :focus-visible)) .stained-pane:not(:hover):not(:focus-visible) { filter: none; opacity: 1; }
+  .stained-pane__number { opacity: .8; transform: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
### Motivation
- The gallery needed a more professional, cohesive, and designed presentation that reads like an architectural stained-glass window of framed photos while remaining smooth, polished, and accessible.

### Description
- Replace row-based grouping with a single responsive grid and render each photo as an individual animated pane driven by `framer-motion` in `src/App.jsx` to provide staggered entrance and focus animations.
- Improve image loading and responsiveness by prioritizing early images (`loading`/`fetchpriority`) and updating `sizes` for multiple breakpoints, and add a subtle scale animation and number overlay for each pane in `src/App.jsx`.
- Overhaul gallery styling in `src/index.css` to a 12-column dense grid with varied pane proportions via `:nth-child()` rules, dark lead-like gutters, rounded framing, inset highlights, a soft vignette overlay, and refined image grading and hover/focus depth.
- Add tablet and mobile layout rules and preserve accessibility with `prefers-reduced-motion` behavior and keyboard/touch navigation support already present in the gallery component.

### Testing
- Ran `npm run build` and the production build completed successfully with generated assets listed by Vite (build succeeded).
- Ran `git diff --check` and no whitespace or diff-check issues were reported.
- Attempted `npx playwright --version` for screenshot capture, but it failed because a browser executable is not available and package downloads are blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80f47fdb18832b96cebbeedc8a4909)