### PR TITLE
Redesign portfolio galleries as SVG photo mosaics

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1091,6 +1091,84 @@ const ProjectCard = ({ project }) => {
   );
 };
 
+const mosaicColumns = (count) => {
+  if (count % 5 === 0) return 5;
+  if (count % 4 === 0) return 4;
+  if (count % 3 === 0) return 3;
+  return Math.min(count, 5);
+};
+
+const MosaicGallery = ({ project, onSelect }) => {
+  const columns = mosaicColumns(project.photos.length);
+  const rows = Math.ceil(project.photos.length / columns);
+  const width = 1200;
+  const height = rows * 285;
+  const points = useMemo(() => {
+    const nodes = Array.from({ length: rows + 1 }, (_, row) =>
+      Array.from({ length: columns + 1 }, (_, column) => {
+        const edgeX = column === 0 || column === columns;
+        const edgeY = row === 0 || row === rows;
+        const xJitter = edgeX ? 0 : (((row * 47 + column * 31) % 97) - 48) * 0.72;
+        const yJitter = edgeY ? 0 : (((row * 29 + column * 53) % 83) - 41) * 0.9;
+        return [column * (width / columns) + xJitter, row * (height / rows) + yJitter];
+      })
+    );
+    return project.photos.map((_, index) => {
+      const row = Math.floor(index / columns);
+      const column = index % columns;
+      return [nodes[row][column], nodes[row][column + 1], nodes[row + 1][column + 1], nodes[row + 1][column]];
+    });
+  }, [columns, project.photos, rows, height]);
+
+  return (
+    <svg className="mosaic-gallery" viewBox={`0 0 ${width} ${height}`} aria-label={`${project.title} photo mosaic`}>
+      <defs>
+        {points.map((polygon, index) => (
+          <clipPath id={`mosaic-${project.id}-${index}`} key={index}>
+            <polygon points={polygon.map(point => point.join(',')).join(' ')} />
+          </clipPath>
+        ))}
+      </defs>
+      {project.photos.map((src, index) => {
+        const polygon = points[index];
+        const xs = polygon.map(([x]) => x);
+        const ys = polygon.map(([, y]) => y);
+        const x = Math.min(...xs);
+        const y = Math.min(...ys);
+        const cellWidth = Math.max(...xs) - x;
+        const cellHeight = Math.max(...ys) - y;
+        return (
+          <g
+            className="mosaic-piece"
+            key={src}
+            role="button"
+            tabIndex="0"
+            aria-label={`View image ${index + 1} from ${project.title}`}
+            onClick={() => onSelect(index)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                onSelect(index);
+              }
+            }}
+          >
+            <image
+              href={src}
+              x={x}
+              y={y}
+              width={cellWidth}
+              height={cellHeight}
+              preserveAspectRatio="xMidYMid slice"
+              clipPath={`url(#mosaic-${project.id}-${index})`}
+            />
+            <polygon className="mosaic-piece__edge" points={polygon.map(point => point.join(',')).join(' ')} />
+          </g>
+        );
+      })}
+    </svg>
+  );
+};
+
 const Portfolio = () => {
   const [active, setActive] = useState(null);
   const [idx, setIdx] = useState(null);
@@ -1249,31 +1327,14 @@ const Portfolio = () => {
                   animate={{opacity:1, y:0}}
                   transition={{duration:0.45}}
                   className="stained-gallery"
-                  style={{ '--pane-count': active.photos.length }}
                 >
-                  <div className="stained-gallery__grid">
-                    {active.photos.map((src, photoIdx) => (
-                      <motion.button
-                        key={src}
-                        initial={{ opacity: 0, scale: 0.985 }}
-                        animate={{ opacity: 1, scale: 1 }}
-                        transition={{ duration: 0.7, delay: Math.min(photoIdx * 0.045, 0.4), ease: [0.16, 1, 0.3, 1] }}
-                        onClick={() => { setIdx(photoIdx); track('gallery_select_image', { project_id: active.id, idx: photoIdx }); }}
-                        className="stained-pane group"
-                        aria-label={`View image ${photoIdx + 1} from ${active.title}`}
-                      >
-                        <img
-                          src={src}
-                          alt={active.captions?.[photoIdx] || `${active.title} production photo ${photoIdx + 1}`}
-                          loading={photoIdx < 4 ? "eager" : "lazy"}
-                          decoding="async"
-                          fetchpriority={photoIdx < 2 ? "high" : "low"}
-                          sizes="(min-width: 900px) 38vw, (min-width: 640px) 50vw, 100vw"
-                        />
-                        <span className="stained-pane__number" aria-hidden="true">{String(photoIdx + 1).padStart(2, '0')}</span>
-                      </motion.button>
-                    ))}
-                  </div>
+                  <MosaicGallery
+                    project={active}
+                    onSelect={(photoIdx) => {
+                      setIdx(photoIdx);
+                      track('gallery_select_image', { project_id: active.id, idx: photoIdx });
+                    }}
+                  />
                 </motion.div>
               ) : (
                 <>

--- a/src/index.css
+++ b/src/index.css
@@ -25,13 +25,21 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 .stained-gallery {
   position: relative;
   isolation: isolate;
-  padding: clamp(0.45rem, 0.8vw, 0.75rem);
-  background: #111;
-  border: 1px solid rgba(255,255,255,.2);
-  border-radius: 1.25rem;
+  background: #f4f4f0;
+  border: 1px solid rgba(255,255,255,.35);
+  border-radius: .35rem;
   box-shadow: 0 28px 80px rgba(0,0,0,.55), inset 0 0 0 1px rgba(255,255,255,.05);
   overflow: hidden;
 }
+
+.mosaic-gallery { display: block; width: 100%; height: auto; background: #f4f4f0; }
+.mosaic-piece { cursor: pointer; outline: none; }
+.mosaic-piece image { filter: saturate(.92) brightness(.86); transition: filter 500ms ease; }
+.mosaic-piece__edge { fill: transparent; stroke: #f4f4f0; stroke-width: 8; vector-effect: non-scaling-stroke; transition: stroke-width 300ms ease; }
+.mosaic-gallery:has(.mosaic-piece:hover) .mosaic-piece:not(:hover) image { filter: saturate(.58) brightness(.55); }
+.mosaic-piece:hover image,
+.mosaic-piece:focus-visible image { filter: saturate(1.04) brightness(1.04); }
+.mosaic-piece:focus-visible .mosaic-piece__edge { stroke: #fff; stroke-width: 13; }
 
 .stained-gallery__grid {
   display: grid;
@@ -133,7 +141,7 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 }
 
 @media (max-width: 640px) {
-  .stained-gallery { padding: .4rem; border-radius: .8rem; }
+  .stained-gallery { border-radius: .25rem; }
   .stained-gallery__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 5rem; gap: .4rem; padding: 0; }
   .stained-pane:nth-child(n) { grid-column: span 1; grid-row: span 2; }
   .stained-pane:nth-child(4n + 1) { grid-column: 1 / -1; grid-row: span 3; }


### PR DESCRIPTION
### Motivation
- Replace the rectangular/black-pane gallery with an irregular-photo mosaic so each dark shape can instead display one of the project photos in a custom, clipped shape.
- Preserve existing gallery interactions and lightbox behavior while improving visual fidelity to the attached reference image.

### Description
- Add `MosaicGallery` component and `mosaicColumns` helper to `src/App.jsx` which lay out project photos into an SVG mosaic of irregular quadrilateral tiles and generate per-tile clip paths.  (new functions in `src/App.jsx`)
- Replace the stained-gallery grid view for project galleries with the `MosaicGallery` SVG and wire `onSelect` to open the existing lightbox so keyboard and click selection reuse existing gallery logic. (modified `Portfolio` render in `src/App.jsx`)
- Ensure accessibility by making each mosaic tile keyboard-focusable and activating on Enter/Space, and preserve ARIA labeling for images and the lightbox. (in `src/App.jsx`)
- Update styles in `src/index.css` to add `.mosaic-gallery` / `.mosaic-piece` rules, adjust gallery background/borders, and add hover/focus visual treatments to match the mosaic aesthetic. (modified `src/index.css`)

### Testing
- Ran a production build with `npm run build` which completed successfully (build artifacts produced; warning about large chunks only). ✅
- Ran `git diff --check` and basic repository status checks which returned clean results, and changes were committed on the branch with the message `Redesign portfolio galleries as photo mosaics`. ✅
- Attempted to install Playwright for screenshot testing (`npx --yes playwright@1.55.0 install chromium`) but it failed due to an npm registry 403, so browser-based automated screenshot tests did not run. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80fa3af334832b853e2f271d57a9b5)