### PR TITLE
Fluid, full-window cursor-responsive mosaic gallery

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1099,29 +1099,77 @@ const mosaicColumns = (count) => {
 };
 
 const MosaicGallery = ({ project, onSelect }) => {
+  const svgRef = useRef(null);
   const columns = mosaicColumns(project.photos.length);
   const rows = Math.ceil(project.photos.length / columns);
   const width = 1200;
-  const height = rows * 285;
-  const points = useMemo(() => {
-    const nodes = Array.from({ length: rows + 1 }, (_, row) =>
+  const height = 760;
+  const baseNodes = useMemo(() =>
+    Array.from({ length: rows + 1 }, (_, row) =>
       Array.from({ length: columns + 1 }, (_, column) => {
         const edgeX = column === 0 || column === columns;
         const edgeY = row === 0 || row === rows;
-        const xJitter = edgeX ? 0 : (((row * 47 + column * 31) % 97) - 48) * 0.72;
-        const yJitter = edgeY ? 0 : (((row * 29 + column * 53) % 83) - 41) * 0.9;
+        const xJitter = edgeX ? 0 : (((row * 47 + column * 31) % 97) - 48) * 1.55;
+        const yJitter = edgeY ? 0 : (((row * 29 + column * 53) % 83) - 41) * 1.65;
         return [column * (width / columns) + xJitter, row * (height / rows) + yJitter];
       })
-    );
+    ), [columns, rows]);
+  const [nodes, setNodes] = useState(baseNodes);
+  const targetRef = useRef({ x: width / 2, y: height / 2, active: false });
+  const currentRef = useRef({ x: width / 2, y: height / 2, strength: 0 });
+
+  useEffect(() => {
+    let frame;
+    const animate = () => {
+      const current = currentRef.current;
+      const target = targetRef.current;
+      current.x += (target.x - current.x) * 0.055;
+      current.y += (target.y - current.y) * 0.055;
+      current.strength += ((target.active ? 1 : 0) - current.strength) * 0.045;
+      const radius = Math.max(width / columns, height / rows) * 1.45;
+      setNodes(baseNodes.map((line, row) => line.map((point, column) => {
+        if (row === 0 || row === rows || column === 0 || column === columns) return point;
+        const dx = point[0] - current.x;
+        const dy = point[1] - current.y;
+        const distance = Math.hypot(dx, dy) || 1;
+        const influence = Math.max(0, 1 - distance / radius) ** 2 * current.strength;
+        return [point[0] + (dx / distance) * 62 * influence, point[1] + (dy / distance) * 48 * influence];
+      })));
+      frame = requestAnimationFrame(animate);
+    };
+    frame = requestAnimationFrame(animate);
+    return () => cancelAnimationFrame(frame);
+  }, [baseNodes, columns, rows]);
+
+  const points = useMemo(() => {
     return project.photos.map((_, index) => {
       const row = Math.floor(index / columns);
       const column = index % columns;
       return [nodes[row][column], nodes[row][column + 1], nodes[row + 1][column + 1], nodes[row + 1][column]];
     });
-  }, [columns, project.photos, rows, height]);
+  }, [columns, project.photos, nodes]);
+
+  const followPointer = useCallback((event) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+    const rect = svg.getBoundingClientRect();
+    targetRef.current = {
+      x: ((event.clientX - rect.left) / rect.width) * width,
+      y: ((event.clientY - rect.top) / rect.height) * height,
+      active: true,
+    };
+  }, []);
 
   return (
-    <svg className="mosaic-gallery" viewBox={`0 0 ${width} ${height}`} aria-label={`${project.title} photo mosaic`}>
+    <svg
+      ref={svgRef}
+      className="mosaic-gallery"
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      aria-label={`${project.title} photo mosaic`}
+      onPointerMove={followPointer}
+      onPointerLeave={() => { targetRef.current = { ...targetRef.current, active: false }; }}
+    >
       <defs>
         {points.map((polygon, index) => (
           <clipPath id={`mosaic-${project.id}-${index}`} key={index}>
@@ -1281,7 +1329,7 @@ const Portfolio = () => {
               }
             }}
           >
-            <div className="max-w-6xl mx-auto">
+            <div className="gallery-dialog-shell mx-auto">
               <div className="sticky top-0 z-10 mb-5 flex flex-col gap-3 text-white bg-black/95 pb-4 pt-2 sm:flex-row sm:items-center sm:justify-between">
                 <div className="max-w-3xl">
                   <div className="text-xs uppercase tracking-[0.2em] opacity-80">{active.role} — {active.year}</div>

--- a/src/index.css
+++ b/src/index.css
@@ -30,16 +30,20 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   border-radius: .35rem;
   box-shadow: 0 28px 80px rgba(0,0,0,.55), inset 0 0 0 1px rgba(255,255,255,.05);
   overflow: hidden;
+  width: 100%;
+  height: max(34rem, calc(100svh - 10.75rem));
 }
 
-.mosaic-gallery { display: block; width: 100%; height: auto; background: #f4f4f0; }
+.gallery-dialog-shell { width: min(100%, 104rem); }
+.mosaic-gallery { display: block; width: 100%; height: 100%; background: #f4f4f0; touch-action: pan-y; }
 .mosaic-piece { cursor: pointer; outline: none; }
-.mosaic-piece image { filter: saturate(.92) brightness(.86); transition: filter 500ms ease; }
-.mosaic-piece__edge { fill: transparent; stroke: #f4f4f0; stroke-width: 8; vector-effect: non-scaling-stroke; transition: stroke-width 300ms ease; }
-.mosaic-gallery:has(.mosaic-piece:hover) .mosaic-piece:not(:hover) image { filter: saturate(.58) brightness(.55); }
+.mosaic-piece image { filter: saturate(.92) brightness(.86); transition: filter 900ms cubic-bezier(.16,1,.3,1); }
+.mosaic-piece__edge { fill: transparent; stroke: #f4f4f0; stroke-width: 7; vector-effect: non-scaling-stroke; transition: stroke-width 650ms cubic-bezier(.16,1,.3,1); }
+.mosaic-gallery:has(.mosaic-piece:hover) .mosaic-piece:not(:hover) image { filter: saturate(.62) brightness(.58); }
 .mosaic-piece:hover image,
 .mosaic-piece:focus-visible image { filter: saturate(1.04) brightness(1.04); }
-.mosaic-piece:focus-visible .mosaic-piece__edge { stroke: #fff; stroke-width: 13; }
+.mosaic-piece:hover .mosaic-piece__edge,
+.mosaic-piece:focus-visible .mosaic-piece__edge { stroke: #fff; stroke-width: 11; }
 
 .stained-gallery__grid {
   display: grid;
@@ -142,6 +146,7 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 
 @media (max-width: 640px) {
   .stained-gallery { border-radius: .25rem; }
+  .stained-gallery { height: max(30rem, calc(100svh - 13.5rem)); }
   .stained-gallery__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 5rem; gap: .4rem; padding: 0; }
   .stained-pane:nth-child(n) { grid-column: span 1; grid-row: span 2; }
   .stained-pane:nth-child(4n + 1) { grid-column: 1 / -1; grid-row: span 3; }
@@ -150,6 +155,8 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .mosaic-piece image,
+  .mosaic-piece__edge,
   .stained-pane,
   .stained-pane img { transition: none; }
   .stained-pane:hover,


### PR DESCRIPTION
### Motivation
- Make the portfolio gallery occupy the available viewport and scale with window size so featured images can be larger and more immersive.
- Give the mosaic tiles more varied, expressive shapes inspired by the provided reference so the wall reads as handcrafted panes rather than a rigid grid.
- Allow the gallery to gently shift which photos are visually emphasized as the user moves the cursor so featuring feels gradual and not jarring.

### Description
- Reworked the mosaic renderer in `src/App.jsx` by fixing the gallery drawing height, using a deterministic `baseNodes` grid with amplified jitter, and introducing `nodes` state that animates via `requestAnimationFrame` toward a pointer-driven `targetRef` so shared cell boundaries subtly ripple toward the cursor (added `svgRef`, `followPointer`, pointer handlers, and easing math). 
- Updated the SVG output to `preserveAspectRatio="none"` and compute clipPaths from the animated `nodes`, keeping the photos clipped to irregular quadrilaterals and preserving accessibility/keyboard handlers for selection. 
- Adjusted styles in `src/index.css` to make the dialog/gallery fill more of the viewport (`.stained-gallery` height and `.mosaic-gallery` height 100%), added a `.gallery-dialog-shell` wrapper for dialog width control, made the mosaic transitions slower and smoother (`transition` timing and edge stroke widths), and added `touch-action: pan-y` plus mobile height tweaks and reduced-motion fallbacks. 

### Testing
- Ran `npm run build` which completed successfully (build output produced assets and reported typical chunk-size warnings). 
- Started the dev server with `npm run dev` and the app became available locally. 
- Ran `git diff --check` / workspace checks which reported no code-style errors. 
- Attempted an automated visual capture via `npx playwright` but the run failed due to the environment returning HTTP 403 when fetching the Playwright package from the registry, so screenshots were not produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81e40a7c1c832bbae37ae7965a6626)