### PR TITLE
Refine gallery cropping/hover behavior and unify dark editorial styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Play, Square, ChevronLeft, ChevronRight, Instagram, Linkedin, Music2, FileDown, Eye, Printer, CheckCircle2, X, Grid3X3, ArrowUpRight } from "lucide-react";
+import { Play, Square, ChevronLeft, ChevronRight, Instagram, Linkedin, Music2, FileDown, Eye, Printer, CheckCircle2, X, Grid3X3, ArrowUpRight, Sparkles } from "lucide-react";
 
 // ---- GA helper (idempotent) ----------------------------------------------
 if (typeof window !== 'undefined' && !window.__hkTrack) {
@@ -742,7 +742,7 @@ const Hero = ({ onSeeWork, onNavigate }) => {
   useEffect(() => { setShaderReady(false); }, [hero]);
 
   return (
-    <section className="relative min-h-[100svh] overflow-hidden bg-black text-white" onMouseEnter={()=>setPaused(true)} onMouseLeave={()=>setPaused(false)}>
+    <section className="home-page relative min-h-[100svh] overflow-hidden bg-black text-white" onMouseEnter={()=>setPaused(true)} onMouseLeave={()=>setPaused(false)}>
       <motion.img
         key={hero}
         src={hero}
@@ -1165,7 +1165,7 @@ const MosaicGallery = ({ project, onSelect }) => {
       ref={svgRef}
       className="mosaic-gallery"
       viewBox={`0 0 ${width} ${height}`}
-      preserveAspectRatio="none"
+      preserveAspectRatio="xMidYMid meet"
       aria-label={`${project.title} photo mosaic`}
       onPointerMove={followPointer}
       onPointerLeave={() => { targetRef.current = { ...targetRef.current, active: false }; }}
@@ -1309,7 +1309,7 @@ const Portfolio = () => {
     }
   }, [active]);
   return (
-    <section className="w-full">
+    <section className="editorial-page portfolio-page w-full">
       {PROJECTS.map((p) => <ProjectCard key={p.id} project={p} />)}
       <AnimatePresence>
         {active && (
@@ -1426,11 +1426,11 @@ const Portfolio = () => {
 };
 
 const About = ({ onNavigate }) => (
-  <section className="py-24 px-6 bg-zinc-100 dark:bg-zinc-900 text-black dark:text-white">
+  <section className="editorial-page about-page py-28 px-6 bg-black text-white">
     <SectionTitle>About</SectionTitle>
     <div className="mx-auto max-w-5xl grid md:grid-cols-12 gap-10 items-start">
       {/* Headshot / card */}
-      <figure className="md:col-span-5 overflow-hidden rounded-2xl shadow-2xl ring-1 ring-black/5 dark:ring-white/10 bg-black relative">
+      <figure className="editorial-image md:col-span-5 overflow-hidden bg-black relative">
         <img
           src={ABOUT.photo}
           alt="Headshot of Henry Kacik"
@@ -1470,7 +1470,7 @@ const About = ({ onNavigate }) => (
         )}
 
         {/* Fun callout: spot me in two photos */}
-        <div className="mt-6 flex items-start gap-3 rounded-xl border border-current/15 bg-black/5 dark:bg-white/5 p-4">
+        <div className="editorial-callout mt-8 flex items-start gap-3 border-y border-white/20 py-5">
           <Sparkles className="mt-0.5 h-5 w-5 opacity-80" aria-hidden="true" />
           <p className="text-sm opacity-90">
             I pop up in <strong>two</strong> production photos on this site — see if you can spot me in the{' '}
@@ -1518,7 +1518,7 @@ const Resume = () => {
   }, [preview]);
 
   return (
-    <section className="py-24 px-6 bg-zinc-100 dark:bg-zinc-900 text-black dark:text-white">
+    <section className="editorial-page resume-page py-28 px-6 bg-black text-white">
       <SectionTitle>Résumé</SectionTitle>
       <div className="mx-auto max-w-6xl grid md:grid-cols-12 gap-8">
         {/* Left column: intro + skills */}
@@ -1532,15 +1532,15 @@ const Resume = () => {
               {RESUME_SUMMARY.map((item, i) => <Pill key={i}>{item}</Pill>)}
             </div>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-6">
-              <div className="rounded-xl border border-black/10 dark:border-white/10 bg-white/40 dark:bg-white/5 p-4">
+              <div className="editorial-stat border-t border-white/20 py-4">
                 <div className="text-xs uppercase tracking-widest opacity-70">Based In</div>
                 <div className="text-sm mt-1">{LINKS.location}</div>
               </div>
-              <div className="rounded-xl border border-black/10 dark:border-white/10 bg-white/40 dark:bg-white/5 p-4">
+              <div className="editorial-stat border-t border-white/20 py-4">
                 <div className="text-xs uppercase tracking-widest opacity-70">Selected Shows</div>
                 <div className="text-sm mt-1">{PROJECTS.length} featured</div>
               </div>
-              <div className="rounded-xl border border-black/10 dark:border-white/10 bg-white/40 dark:bg-white/5 p-4">
+              <div className="editorial-stat border-t border-white/20 py-4">
                 <div className="text-xs uppercase tracking-widest opacity-70">Education</div>
                 <div className="text-sm mt-1">Emerson College</div>
               </div>
@@ -1550,7 +1550,7 @@ const Resume = () => {
 
         {/* Right column: actions card */}
         <div className="md:col-span-5">
-          <div className="rounded-2xl border border-black/10 dark:border-white/10 bg-white/60 dark:bg-white/5 p-6">
+          <div className="editorial-download border-y border-white/25 py-6">
             <h3 className="text-base font-semibold mb-3" style={{ fontFamily: '"Fraunces", serif' }}>Get the PDF</h3>
             <p className="text-sm opacity-85 mb-4">Preview in your browser or download a copy.</p>
             <div className="flex flex-wrap gap-3">
@@ -1731,17 +1731,23 @@ export default function HenryKacikSite() {
       });
     });
   }, []);
-  const go = useCallback((r) => { if (window.location.hash.slice(1) === r) return; if (lxMode) { setPreFade(true); setRenderRoute(currentRoute); setTimeout(() => { window.location.hash = r; }, 700); } else { setPreFade(false); window.location.hash = r; } }, [currentRoute, lxMode]);
+  const go = useCallback((r) => {
+    if (window.location.hash.slice(1) === r) return;
+    // Change the route immediately so navigation can never leave an empty black
+    // stage behind. The cue overlay remains a visual layer, not a route gate.
+    setPreFade(false);
+    window.location.hash = r;
+  }, []);
   // Route transition
   useEffect(() => {
-    if (lxMode) {
-      setCueNumber(cueRef.current);
-      const t0 = setTimeout(() => setShowCue(true), 40);
-      const t1 = setTimeout(() => { setShowCue(false); setRenderRoute(currentRoute); }, 40 + 1600);
-      const t2 = setTimeout(() => setPreFade(false), 40 + 1600 + 100);
-      cueRef.current = cueRef.current + 1;
-      return () => { clearTimeout(t0); clearTimeout(t1); clearTimeout(t2); };
-    } else { setShowCue(false); setPreFade(false); setRenderRoute(currentRoute); }
+    setRenderRoute(currentRoute);
+    setPreFade(false);
+    if (!lxMode) { setShowCue(false); return; }
+    setCueNumber(cueRef.current);
+    setShowCue(true);
+    cueRef.current += 1;
+    const timer = window.setTimeout(() => setShowCue(false), 1100);
+    return () => window.clearTimeout(timer);
   }, [currentRoute, lxMode]);
 
   // Dynamic document title
@@ -1764,7 +1770,7 @@ export default function HenryKacikSite() {
 </a>
       {lxMode && preFade && <PreFadeOverlay />}
       {lxMode && showCue && <CueOverlay cue={cueNumber} />}
-      {(!showCue) && (
+      {(
         lxMode ? (
           <motion.div initial={{opacity:0}} animate={{opacity: preFade ? 0 : 1}} transition={{ duration: 0.7, ease: 'easeInOut' }}>
             <Nav route={renderRoute} onNav={go} lxMode={lxMode} setLxMode={setLxMode} />

--- a/src/index.css
+++ b/src/index.css
@@ -25,25 +25,30 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 .stained-gallery {
   position: relative;
   isolation: isolate;
-  background: #f4f4f0;
-  border: 1px solid rgba(255,255,255,.35);
-  border-radius: .35rem;
+  background: #070707;
+  border: 1px solid rgba(255,255,255,.18);
+  border-radius: 0;
   box-shadow: 0 28px 80px rgba(0,0,0,.55), inset 0 0 0 1px rgba(255,255,255,.05);
   overflow: hidden;
   width: 100%;
-  height: max(34rem, calc(100svh - 10.75rem));
+  aspect-ratio: 30 / 19;
+  height: auto;
+  max-height: calc(100svh - 10.75rem);
 }
 
 .gallery-dialog-shell { width: min(100%, 104rem); }
-.mosaic-gallery { display: block; width: 100%; height: 100%; background: #f4f4f0; touch-action: pan-y; }
-.mosaic-piece { cursor: pointer; outline: none; }
+.mosaic-gallery { display: block; width: 100%; height: 100%; background: #070707; touch-action: pan-y; }
+.mosaic-piece { cursor: pointer; outline: none; transform-box: fill-box; transform-origin: center; transition: transform 700ms cubic-bezier(.16,1,.3,1), opacity 500ms ease; }
 .mosaic-piece image { filter: saturate(.92) brightness(.86); transition: filter 900ms cubic-bezier(.16,1,.3,1); }
-.mosaic-piece__edge { fill: transparent; stroke: #f4f4f0; stroke-width: 7; vector-effect: non-scaling-stroke; transition: stroke-width 650ms cubic-bezier(.16,1,.3,1); }
+.mosaic-piece__edge { fill: transparent; stroke: #090909; stroke-width: 10; vector-effect: non-scaling-stroke; transition: stroke 650ms cubic-bezier(.16,1,.3,1), stroke-width 650ms cubic-bezier(.16,1,.3,1); }
+.mosaic-gallery:has(.mosaic-piece:hover) .mosaic-piece:not(:hover) { opacity: .58; transform: scale(.985); }
 .mosaic-gallery:has(.mosaic-piece:hover) .mosaic-piece:not(:hover) image { filter: saturate(.62) brightness(.58); }
 .mosaic-piece:hover image,
 .mosaic-piece:focus-visible image { filter: saturate(1.04) brightness(1.04); }
+.mosaic-piece:hover,
+.mosaic-piece:focus-visible { transform: scale(1.1); }
 .mosaic-piece:hover .mosaic-piece__edge,
-.mosaic-piece:focus-visible .mosaic-piece__edge { stroke: #fff; stroke-width: 11; }
+.mosaic-piece:focus-visible .mosaic-piece__edge { stroke: #fff; stroke-width: 7; }
 
 .stained-gallery__grid {
   display: grid;
@@ -146,22 +151,39 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 
 @media (max-width: 640px) {
   .stained-gallery { border-radius: .25rem; }
-  .stained-gallery { height: max(30rem, calc(100svh - 13.5rem)); }
+  .stained-gallery { aspect-ratio: 4 / 5; max-height: calc(100svh - 13.5rem); }
   .stained-gallery__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 5rem; gap: .4rem; padding: 0; }
   .stained-pane:nth-child(n) { grid-column: span 1; grid-row: span 2; }
   .stained-pane:nth-child(4n + 1) { grid-column: 1 / -1; grid-row: span 3; }
   .stained-gallery__grid:has(.stained-pane:is(:hover, :focus-visible)) .stained-pane:not(:hover):not(:focus-visible) { filter: none; opacity: 1; }
   .stained-pane__number { opacity: .8; transform: none; }
+  .mosaic-piece:hover, .mosaic-piece:focus-visible { transform: scale(1.045); }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .mosaic-piece image,
+  .mosaic-piece,
   .mosaic-piece__edge,
   .stained-pane,
   .stained-pane img { transition: none; }
   .stained-pane:hover,
   .stained-pane:focus-visible { transform: none; }
 }
+
+/* --- shared editorial language across primary pages --- */
+.editorial-page { min-height: calc(100svh - 4rem); background: #050505; color: #fff; }
+.editorial-page > h2 { max-width: 64rem; margin-left: auto; margin-right: auto; padding-bottom: 1.25rem; border-bottom: 1px solid rgba(255,255,255,.22); }
+.editorial-page h2,
+.editorial-page h3 { font-weight: 400; letter-spacing: -.025em; }
+.about-page p,
+.resume-page p { color: rgba(255,255,255,.7); }
+.editorial-image { border-top: 1px solid rgba(255,255,255,.3); border-bottom: 1px solid rgba(255,255,255,.3); padding: .65rem 0; }
+.editorial-callout strong { color: #fff; font-weight: 500; }
+.editorial-stat { background: transparent; }
+.editorial-download { background: transparent; }
+.portfolio-page .portfolio-project { border-bottom: 1px solid rgba(255,255,255,.16); }
+.portfolio-page .portfolio-project h2 { font-family: "Fraunces", serif; font-weight: 400; letter-spacing: -.03em; }
+.home-page h1 { max-width: 12ch; font-weight: 400; line-height: .95; letter-spacing: -.04em; }
 
 /* --- contact: restrained editorial directory --- */
 .contact-page { min-height: calc(100svh - 4rem); background: #050505; }


### PR DESCRIPTION
### Motivation
- Prevent photos from being visually warped in the mosaic and ensure images are cropped to their frames instead of stretched. 
- Move the gallery and page chrome away from bright white so the site reads better on a mostly-black background. 
- Make gallery hover/interaction feel intentional by enlarging the hovered image and subtly de-emphasizing siblings. 
- Fix navigation behavior so route buttons (e.g. About) reliably show their sections and unify the look of Home, About, Portfolio, and Résumé around the contact page aesthetic.

### Description
- Preserve image aspect and cropping in the SVG mosaic by changing `preserveAspectRatio` to `xMidYMid meet` (MosaicGallery) and keeping images clipped to polygon frames, and adjust gallery sizing to use `aspect-ratio` so panes are not stretched. (src/App.jsx, src/index.css)
- Replace the gallery's white surfaces with a near-black treatment and reduce bright borders, update mosaic piece visuals to add intentional transform effects and focus styles, and make non-hovered tiles subtly shrink and dim. (src/index.css)
- Introduce shared editorial classes (`.editorial-page`, `.editorial-image`, `.editorial-callout`, `.editorial-stat`, `.editorial-download`, `.portfolio-page`, `.home-page`) and apply them to Home, About, Portfolio, and Résumé to align their dark, restrained look with the contact page. (src/App.jsx, src/index.css)
- Make the hovered/keyboard-focused mosaic tile grow (`transform: scale(...)`) while neighbors desaturate and scale down slightly, and preserve reduced-motion support for accessibility. (src/index.css)
- Change navigation routing behavior so the hash updates immediately (avoiding a temporarily blank stage) and adjust the theatrical cue so it is an overlay rather than blocking content; also add the missing `Sparkles` icon import used in About. (src/App.jsx)

### Testing
- Ran `npm run build` and the production build completed successfully (vite build output produced bundles; noted chunk-size warnings only). 
- Started the dev server and fetched the root via `curl -I http://127.0.0.1:5173` which returned `200 OK`. 
- Ran `git diff --check` and repository status checks to verify the working tree changes are clean and syntactically valid. 
- No headless browser was available in the environment, so an automated visual screenshot was not captured; manual visual QA is recommended in a browser to confirm the new hover/cropping behavior and the unified dark styling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a81e6ba0638832bac4c3eed963d10c0)