### PR TITLE
Fix blackout cue behavior and improve gallery image presentation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -484,7 +484,7 @@ const useLazyLoad = (options) => {
 
 const CueOverlay = ({ cue }) => (
   <AnimatePresence>
-    <motion.div key={`cue-${cue}`} initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.35 }} className="pointer-events-none fixed inset-0 z-[60] grid place-items-center bg-black/82">
+    <motion.div key={`cue-${cue}`} initial={{ opacity: 1 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.35 }} className="pointer-events-none fixed inset-0 z-[60] grid place-items-center bg-black">
       <motion.div aria-hidden className="absolute inset-0" initial={{ opacity: 0.35, scale: 0.9 }} animate={{ opacity: 0, scale: 1.5 }} transition={{ duration: 1.2, ease: 'easeOut' }} style={{ background: 'radial-gradient(closest-side, rgba(255,255,255,0.08), rgba(255,255,255,0.0) 60%)', mixBlendMode: 'screen' }} />
       <div className="text-center">
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: [0, 1, 1, 0] }} transition={{ duration: 1.6, times: [0, 0.1, 0.85, 0.95], ease: 'easeInOut' }} className="font-mono text-sm uppercase tracking-[0.35em] text-white/80">Standby LX {cue}.</motion.div>
@@ -1044,6 +1044,7 @@ const ProjectCard = ({ project }) => {
   const opts = useMemo(() => ({ threshold: 0.2 }), []);
   const [ref, visible] = useLazyLoad(opts);
   const [ratioStr, setRatioStr] = useState('16 / 9');
+  const [imageLoaded, setImageLoaded] = useState(false);
   const open = useCallback(() => { const ev = new CustomEvent('openGallery', { detail: project }); window.dispatchEvent(ev); }, [project]);
   return (
     <div ref={ref} className="portfolio-project relative flex flex-col md:grid md:grid-cols-12">
@@ -1053,8 +1054,8 @@ const ProjectCard = ({ project }) => {
 >
   {visible && (
     <motion.img
-      initial={{opacity:0, scale:1.02}}
-      animate={{opacity:1, scale:1}}
+      initial={false}
+      animate={{opacity:imageLoaded ? 1 : 0, scale:imageLoaded ? 1 : 1.015}}
       transition={{duration:0.7, ease:'easeOut'}}
       src={project.hero}
       alt={project.captions?.[0] || project.title}
@@ -1068,6 +1069,7 @@ const ProjectCard = ({ project }) => {
         const w = e.target.naturalWidth || 16;
         const h = e.target.naturalHeight || 9;
           setRatioStr(`${w} / ${h}`);
+          setImageLoaded(true);
         }}
       />
     )}
@@ -1104,8 +1106,9 @@ const MosaicGallery = ({ project, onSelect }) => {
   const layoutFor = useCallback((heroIndex) => {
     const heroRow = Math.floor(heroIndex / columns);
     const heroColumn = heroIndex % columns;
-    const columnWeights = Array.from({ length: columns }, (_, column) => column === heroColumn ? 1.85 : 1);
-    const rowWeights = Array.from({ length: rows }, (_, row) => row === heroRow ? 1.7 : 1);
+    const hasHero = heroIndex !== null;
+    const columnWeights = Array.from({ length: columns }, (_, column) => hasHero && column === heroColumn ? 1.85 : 1);
+    const rowWeights = Array.from({ length: rows }, (_, row) => hasHero && row === heroRow ? 1.7 : 1);
     const columnTotal = columnWeights.reduce((sum, value) => sum + value, 0);
     const rowTotal = rowWeights.reduce((sum, value) => sum + value, 0);
     const xLines = columnWeights.reduce((lines, value) => [...lines, lines.at(-1) + width * value / columnTotal], [0]);
@@ -1120,8 +1123,9 @@ const MosaicGallery = ({ project, onSelect }) => {
       })
     );
   }, [columns, rows]);
-  const [heroIndex, setHeroIndex] = useState(0);
-  const [nodes, setNodes] = useState(() => layoutFor(0));
+  const [heroIndex, setHeroIndex] = useState(null);
+  const [loadedImages, setLoadedImages] = useState(() => new Set());
+  const [nodes, setNodes] = useState(() => layoutFor(null));
   const nodesRef = useRef(nodes);
 
   useEffect(() => {
@@ -1158,7 +1162,8 @@ const MosaicGallery = ({ project, onSelect }) => {
       viewBox={`0 0 ${width} ${height}`}
       preserveAspectRatio="xMidYMid meet"
       aria-label={`${project.title} photo mosaic`}
-      data-hero-index={heroIndex}
+      data-hero-index={heroIndex ?? ''}
+      onPointerLeave={() => setHeroIndex(null)}
     >
       <defs>
         {points.map((polygon, index) => (
@@ -1193,13 +1198,19 @@ const MosaicGallery = ({ project, onSelect }) => {
             }}
           >
             <image
+              className={loadedImages.has(index) ? 'is-loaded' : ''}
               href={src}
               x={x}
               y={y}
               width={cellWidth}
               height={cellHeight}
-              preserveAspectRatio="xMidYMid slice"
+              preserveAspectRatio="xMidYMid meet"
               clipPath={`url(#mosaic-${project.id}-${index})`}
+              onLoad={() => setLoadedImages(previous => {
+                const next = new Set(previous);
+                next.add(index);
+                return next;
+              })}
             />
             <polygon className="mosaic-piece__edge" points={polygon.map(point => point.join(',')).join(' ')} />
           </g>
@@ -1692,14 +1703,24 @@ export default function HenryKacikSite() {
   const currentRoute = routeBase(route);
   const [_dark] = useDarkMode();
   const [lxMode, setLxMode] = useState(true);
-  const cueRef = useRef(1);
+  const cueRef = useRef(2);
   const [preFade, setPreFade] = useState(false);
-  const [showCue, setShowCue] = useState(false);
+  const [showCue, setShowCue] = useState(true);
   const [cueNumber, setCueNumber] = useState(1);
   const [renderRoute, setRenderRoute] = useState(currentRoute);
   const previousRouteRef = useRef(currentRoute);
+  const hasEnteredRef = useRef(false);
   const mainRef = useRef(null);
   useEffect(() => { injectFonts(); }, []);
+  // Start every visit on a true blackout, then call the first cue before the
+  // site is revealed. This is deliberately independent of image loading.
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      hasEnteredRef.current = true;
+      setShowCue(false);
+    }, 1600);
+    return () => window.clearTimeout(timer);
+  }, []);
   // Inject project schema once on mount
   useEffect(() => { try { injectProjectSchema(); } catch {} }, []);
   // Tamer image preloading: respect Data Saver, only hero + first 2 per project
@@ -1735,13 +1756,15 @@ export default function HenryKacikSite() {
   useEffect(() => {
     if (previousRouteRef.current === currentRoute) return;
     previousRouteRef.current = currentRoute;
-    setRenderRoute(currentRoute);
     setPreFade(false);
-    if (!lxMode) { setShowCue(false); return; }
+    if (!lxMode || !hasEnteredRef.current) { setRenderRoute(currentRoute); return; }
     setCueNumber(cueRef.current);
     setShowCue(true);
     cueRef.current += 1;
-    const timer = window.setTimeout(() => setShowCue(false), 1100);
+    const timer = window.setTimeout(() => {
+      setRenderRoute(currentRoute);
+      setShowCue(false);
+    }, 1600);
     return () => window.clearTimeout(timer);
   }, [currentRoute, lxMode]);
   useEffect(() => { if (!lxMode) setShowCue(false); }, [lxMode]);

--- a/src/index.css
+++ b/src/index.css
@@ -36,15 +36,16 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
   max-height: calc(100svh - 10.75rem);
 }
 
-.gallery-dialog-shell { width: min(100%, 104rem); }
+.gallery-dialog-shell { width: min(100%, 112rem); }
 .mosaic-gallery { display: block; width: 100%; height: 100%; background: #070707; touch-action: pan-y; }
 .mosaic-piece { cursor: pointer; outline: none; transform-box: fill-box; transform-origin: center; transition: transform 700ms cubic-bezier(.16,1,.3,1), opacity 500ms ease; }
-.mosaic-piece image { filter: saturate(.92) brightness(.86); transition: filter 900ms cubic-bezier(.16,1,.3,1); }
+.mosaic-piece image { opacity: 0; filter: saturate(.72) brightness(.62); transition: opacity 650ms ease, filter 900ms cubic-bezier(.16,1,.3,1); }
+.mosaic-piece image.is-loaded { opacity: 1; }
 .mosaic-piece__edge { fill: transparent; stroke: #090909; stroke-width: 10; vector-effect: non-scaling-stroke; transition: stroke 650ms cubic-bezier(.16,1,.3,1), stroke-width 650ms cubic-bezier(.16,1,.3,1); }
 .mosaic-gallery:has(.mosaic-piece--hero) .mosaic-piece:not(.mosaic-piece--hero) { opacity: .68; }
 .mosaic-gallery:has(.mosaic-piece--hero) .mosaic-piece:not(.mosaic-piece--hero) image { filter: saturate(.7) brightness(.66); }
 .mosaic-piece--hero image { filter: saturate(1.04) brightness(1.04); }
-.mosaic-piece--hero .mosaic-piece__edge { stroke: #fff; stroke-width: 7; }
+.mosaic-piece--hero .mosaic-piece__edge { stroke: #090909; stroke-width: 10; }
 
 .stained-gallery__grid {
   display: grid;


### PR DESCRIPTION
### Motivation

- Ensure the theatrical “Go” cue displays on a true black screen immediately on load and before any page content is rendered. 
- Improve the portfolio/gallery UX by removing the white hover border, preventing abrupt image flashes during load, and showing photos more centered/contained in their panes. 
- Provide an unfeatured/resting appearance for gallery panes when the pointer is not over the mosaic and avoid showing partial/over-cropped photos.

### Description

- Updated `src/App.jsx` to show the `CueOverlay` as a full blackout (background black, initial opacity on) and to start the app hidden behind a blackout for the first ~1.6s using a `hasEnteredRef`, ensuring the cue plays before the site reveal and before route renders; route changes now wait for the cue to finish before swapping pages when `lxMode` is enabled. 
- Added image-load awareness to project hero images via a new `imageLoaded` state in `ProjectCard` so project hero images animate in only after their `onLoad` fires and use `object-fit: contain` to show photos more centered. 
- Reworked `MosaicGallery` logic to default to no featured hero (`heroIndex` starts `null`) and to compute layout accordingly, added `onPointerLeave` to revert to the neutral unfeatured layout, and track per-image loads with `loadedImages` to fade images in once loaded. 
- Adjusted gallery image `preserveAspectRatio` to `xMidYMid meet`, removed the white hover stroke by styling `.mosaic-piece__edge` for a neutral resting edge, and increased `.gallery-dialog-shell` width; corresponding CSS changes were made in `src/index.css` to fade images in (`.mosaic-piece image` opacity transition and `.is-loaded` class) and remove the bright hero border. 

### Testing

- Ran `npm run build` and the production build completed successfully with chunk warnings only (build finished). 
- Started the dev server with `npm run dev -- --host 0.0.0.0` and Vite reported the server ready and reachable locally/network. 
- Ran `git diff --check` and `git status --short --branch` to verify there were no diff-check failures and the working tree reflected the changes. 
- Attempted automated browser tooling: Playwright was not present in the environment so screenshot automation was not executed, and `make_pr` is not available here so an automated PR creation step did not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a823a1981bc832baebc297d79ae9a0e)