### PR TITLE
Smooth page loading and restore the homepage spotlight

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -759,13 +759,13 @@ const Hero = ({ onSeeWork, onNavigate }) => {
       {!prefersReduced && !coarsePointer && (
    <AnimatePresence initial={false}>
      <motion.div
-       key={`${heroIdx}-${shaderReady ? 'ready' : 'loading'}`}
+       key={hero}
        className="absolute inset-0"
        initial={{ opacity: 0 }}
        animate={{ opacity: shaderReady ? 1 : 0 }}
        exit={{ opacity: 0 }}
        transition={{ duration: 1.2, ease: "easeInOut" }}
-       style={{ pointerEvents: 'none' }}   // let clicks hit the buttons below
+       style={{ pointerEvents: 'none' }}
      >
        <ParticleHero
          imageUrl={hero}
@@ -821,9 +821,11 @@ const ParticleHero = ({ imageUrl, onReady, onError }) => {
         // Capability gating (keep it light; avoid importing three unless we pass)
         const prefersReduced = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
         const coarsePointer  = window.matchMedia?.('(pointer: coarse)')?.matches;
-        const cores = navigator.hardwareConcurrency || 4;
-        const memoryGB = navigator.deviceMemory || 4;
-        const enableFx = !prefersReduced && !coarsePointer && cores >= 6 && memoryGB >= 4;
+        // The effect is progressively enhanced for precise pointers. Do not gate
+        // it on hardwareConcurrency/deviceMemory: those values are frequently
+        // missing or deliberately reduced by browsers, which made the spotlight
+        // disappear on otherwise capable machines.
+        const enableFx = !prefersReduced && !coarsePointer;
 
         if (!enableFx) {
           onError?.();
@@ -972,9 +974,11 @@ const ParticleHero = ({ imageUrl, onReady, onError }) => {
           }
         };
         const onLeave = () => { mouseRef.current.target = 0; };
-        container.addEventListener('pointermove', onPointer, { passive: true });
-        container.addEventListener('pointerdown', onPointer, { passive: true });
-        container.addEventListener('pointerleave', onLeave);
+        // The canvas is pointer-events:none so it never blocks the hero controls.
+        // Listen on the window and map the pointer back into the hero instead.
+        window.addEventListener('pointermove', onPointer, { passive: true });
+        window.addEventListener('pointerdown', onPointer, { passive: true });
+        window.addEventListener('pointerleave', onLeave, { passive: true });
 
         let start;
         const tick = () => {
@@ -1015,9 +1019,9 @@ const ParticleHero = ({ imageUrl, onReady, onError }) => {
         cleanup = () => {
           if (animRef.current) cancelAnimationFrame(animRef.current);
           window.removeEventListener('resize', onResize);
-          container.removeEventListener('pointermove', onPointer);
-          container.removeEventListener('pointerdown', onPointer);
-          container.removeEventListener('pointerleave', onLeave);
+          window.removeEventListener('pointermove', onPointer);
+          window.removeEventListener('pointerdown', onPointer);
+          window.removeEventListener('pointerleave', onLeave);
           document.removeEventListener('visibilitychange', onVis);
           observer.disconnect();
           mat.dispose();
@@ -1702,24 +1706,20 @@ export default function HenryKacikSite() {
   const { route } = useHashRoute();
   const currentRoute = routeBase(route);
   const [_dark] = useDarkMode();
-  const [lxMode, setLxMode] = useState(true);
+  // Smooth crossfades are the professional default; the longer theatrical cue
+  // sequence remains available from the navigation control as an optional mode.
+  const [lxMode, setLxMode] = useState(false);
   const cueRef = useRef(2);
   const [preFade, setPreFade] = useState(false);
-  const [showCue, setShowCue] = useState(true);
+  const [showCue, setShowCue] = useState(false);
   const [cueNumber, setCueNumber] = useState(1);
   const [renderRoute, setRenderRoute] = useState(currentRoute);
   const previousRouteRef = useRef(currentRoute);
   const hasEnteredRef = useRef(false);
   const mainRef = useRef(null);
   useEffect(() => { injectFonts(); }, []);
-  // Start every visit on a true blackout, then call the first cue before the
-  // site is revealed. This is deliberately independent of image loading.
   useEffect(() => {
-    const timer = window.setTimeout(() => {
-      hasEnteredRef.current = true;
-      setShowCue(false);
-    }, 1600);
-    return () => window.clearTimeout(timer);
+    hasEnteredRef.current = true;
   }, []);
   // Inject project schema once on mount
   useEffect(() => { try { injectProjectSchema(); } catch {} }, []);
@@ -1780,7 +1780,10 @@ export default function HenryKacikSite() {
   }, [renderRoute]);
 
   // Focus main on route changes
-  useEffect(() => { mainRef.current?.focus?.(); }, [renderRoute]);
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+    mainRef.current?.focus?.({ preventScroll: true });
+  }, [renderRoute]);
   const onSeeWork = useCallback(() => go("portfolio"), [go]);
   return (
     <div className="min-h-screen bg-black text-white" style={{ fontFamily: 'Jost, Futura, "Century Gothic", system-ui, sans-serif' }}>
@@ -1803,8 +1806,15 @@ export default function HenryKacikSite() {
             <Footer />
           </motion.div>
         ) : (
-          <AnimatePresence mode="wait">
-            <motion.div key={renderRoute} initial={{opacity:0}} animate={{opacity:1}} exit={{opacity:0}} transition={{duration:0.6, ease:'easeInOut'}}>
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={renderRoute}
+              className="page-transition"
+              initial={{opacity:0, y:8}}
+              animate={{opacity:1, y:0}}
+              exit={{opacity:0, y:-4}}
+              transition={{duration:0.38, ease:[0.22, 1, 0.36, 1]}}
+            >
               <Nav route={renderRoute} onNav={go} lxMode={lxMode} setLxMode={setLxMode} />
               <main id="main" ref={mainRef} tabIndex="-1">
                 {renderRoute === "home" && <Hero onSeeWork={onSeeWork} onNavigate={go} />}

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,15 @@ html, body, #root {
   scroll-behavior: smooth;
 }
 
+body {
+  margin: 0;
+  background: #000;
+}
+
+/* Keep page swaps and decoded imagery on their own compositor layers. */
+.page-transition { will-change: opacity, transform; }
+img { transition: opacity 500ms cubic-bezier(.22,1,.36,1); }
+
 img {
   image-orientation: from-image;
 }
@@ -158,6 +167,9 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 }
 
 @media (prefers-reduced-motion: reduce) {
+  html, body, #root { scroll-behavior: auto; }
+  .page-transition { will-change: auto; }
+  img { transition: none; }
   .mosaic-piece image,
   .mosaic-piece,
   .mosaic-piece__edge,


### PR DESCRIPTION
### Motivation
- The homepage spotlight effect was not reliably visible and page loads felt abrupt, so the UI should reveal smoothly and appear professional.
- Pointer-driven spotlight interaction must not block hero controls or be silently disabled on capable devices.
- Route changes should not leave pages scrolled or focused incorrectly, and reduced-motion preferences must be respected.

### Description
- Restore the hero spotlight by keeping the WebGL layer stable and preventing it from remounting by changing the overlay key to `hero` and removing brittle gating on `navigator.hardwareConcurrency`/`deviceMemory` (logic now uses `enableFx` computed from motion and pointer precision only). 
- Make pointer tracking robust by listening for pointer events at the `window` level and mapping them into the hero, and ensure the canvas does not block UI by using `pointer-events:none` for the overlay and handling add/remove of listeners accordingly in `ParticleHero` and `Hero` (`ParticleHero`, `onPointer`, `onLeave`).
- Make smooth crossfades the default navigation experience by defaulting `lxMode` to a smooth mode (`false`), reducing the initial blackout, and adding a compact, accelerated page-entry animation using `AnimatePresence` with a `page-transition` motion wrapper and CSS compositor hints.
- Improve load visual stability and image fades by adding a stable black `body` background, an image opacity transition in `index.css`, `will-change` hints for page transitions, and a forced scroll/focus reset on route changes via `window.scrollTo` and `mainRef.focus({ preventScroll: true })` while continuing to honor `prefers-reduced-motion`.

### Testing
- Built the production bundle with `npm run build` and the build completed successfully (Vite warnings about chunk size / large `three` module were observed but build succeeded).
- Verified code linting/consistency with `git diff --check` (no check failures reported) and repository status commands returned the expected modified files.
- Served the dev site and verified main document returned over HTTP using `curl` (index HTML served and `src/main.jsx` referenced).
- Automated browser screenshot/testing was not available because Playwright/Chromium was not present in the environment, so no visual regression screenshots were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a823d3251cc832b9045fcdd199f00e1)