### PR TITLE
Restore opening theatrical cue and bump Pages actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: dist
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -482,8 +482,8 @@ const useLazyLoad = (options) => {
   return [ref, visible];
 };
 
-const CueOverlay = ({ cue }) => (
-    <motion.div key={`cue-${cue}`} initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.35 }} className="pointer-events-none fixed inset-0 z-[60] grid place-items-center bg-black">
+const CueOverlay = ({ cue, opening = false }) => (
+    <motion.div key={`cue-${cue}`} initial={{ opacity: opening ? 1 : 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.35 }} className="pointer-events-none fixed inset-0 z-[60] grid place-items-center bg-black">
       <motion.div aria-hidden className="absolute inset-0" initial={{ opacity: 0.35, scale: 0.9 }} animate={{ opacity: 0, scale: 1.5 }} transition={{ duration: 1.2, ease: 'easeOut' }} style={{ background: 'radial-gradient(closest-side, rgba(255,255,255,0.08), rgba(255,255,255,0.0) 60%)', mixBlendMode: 'screen' }} />
       <div className="text-center">
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: [0, 1, 1, 0] }} transition={{ duration: 1.6, times: [0, 0.1, 0.85, 0.95], ease: 'easeInOut' }} className="font-mono text-sm uppercase tracking-[0.35em] text-white/80">Standby LX {cue}.</motion.div>
@@ -1702,8 +1702,9 @@ export default function HenryKacikSite() {
   // crossfades immediately behind the cue so neither mode can expose a blank page.
   const [lxMode, setLxMode] = useState(true);
   const cueRef = useRef(2);
-  const [showCue, setShowCue] = useState(false);
+  const [showCue, setShowCue] = useState(true);
   const [cueNumber, setCueNumber] = useState(1);
+  const [openingCue, setOpeningCue] = useState(true);
   const [renderRoute, setRenderRoute] = useState(currentRoute);
   const previousRouteRef = useRef(currentRoute);
   const hasEnteredRef = useRef(false);
@@ -1711,6 +1712,11 @@ export default function HenryKacikSite() {
   useEffect(() => { injectFonts(); }, []);
   useEffect(() => {
     hasEnteredRef.current = true;
+    const timer = window.setTimeout(() => {
+      setShowCue(false);
+      setOpeningCue(false);
+    }, 1750);
+    return () => window.clearTimeout(timer);
   }, []);
   // Inject project schema once on mount
   useEffect(() => { try { injectProjectSchema(); } catch {} }, []);
@@ -1748,6 +1754,7 @@ export default function HenryKacikSite() {
     previousRouteRef.current = currentRoute;
     setRenderRoute(currentRoute);
     if (!lxMode || !hasEnteredRef.current) return;
+    setOpeningCue(false);
     setCueNumber(cueRef.current);
     setShowCue(true);
     cueRef.current += 1;
@@ -1780,7 +1787,7 @@ export default function HenryKacikSite() {
   Skip to content
 </a>
       <AnimatePresence>
-        {lxMode && showCue && <CueOverlay cue={cueNumber} />}
+        {lxMode && showCue && <CueOverlay cue={cueNumber} opening={openingCue} />}
       </AnimatePresence>
           <AnimatePresence mode="wait" initial={false}>
             <motion.div


### PR DESCRIPTION
### Motivation

- Resolve GitHub Actions deprecation warnings about Node.js 20 by updating Pages-related actions to versions that run on Node 24. 
- Fix a poor first-page visual where the site was flashing the content before the theatrical load-in overlay appeared. 

### Description

- Updated `.github/workflows/deploy.yml` to use `actions/upload-pages-artifact@v4` and `actions/deploy-pages@v5` so the workflow runs cleanly under the Node 24 runtime. 
- Restored the initial theatrical blackout/cue by adding an `opening` prop to `CueOverlay` and a new `openingCue` state so cue 1 displays immediately on first load and then times out. 
- Made `showCue` start visible on mount and added a timed hide (1750ms) to avoid the page flashing before the overlay appears, while preserving subsequent numbered cues for route transitions. 
- Tied route-change behavior to the same cue overlay so navigation transitions reuse the same presentation and timing logic. 

### Testing

- Ran `npm install` and `npm run build` and the production build completed successfully without runtime build errors. 
- Ran static checks `git diff --check` and `git status --short` with no reported issues. 
- Attempted remote inspection of action release tags and a headless browser check, but outbound requests were blocked by the environment so those remote checks could not be completed (network/403); local build and lint checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8245722e9c832baf802570cde4096a)