### PR TITLE
Start theatrical opening cue in HTML and update Pages artifact upload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,19 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Build the Pages artifact explicitly so upload-artifact runs on Node 24.
+      # upload-pages-artifact@v4 currently delegates to upload-artifact@v4,
+      # which produces GitHub's Node 20 deprecation annotation.
+      - name: Package Pages artifact
+        run: tar --dereference --hard-dereference --directory dist -cvf "$RUNNER_TEMP/github-pages.tar" .
+
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
-          path: dist
+          name: github-pages
+          path: ${{ runner.temp }}/github-pages.tar
+          retention-days: 1
+          if-no-files-found: error
 
   deploy:
     needs: build

--- a/index.html
+++ b/index.html
@@ -92,9 +92,29 @@
   </script>
   </head>
   <body class="bg-black">
+    <!-- This opening cue is deliberately server-rendered so the entrance starts
+         before React, fonts, and the hero photograph have finished downloading. -->
+    <style>
+      #opening-cue{position:fixed;inset:0;z-index:9999;display:grid;place-items:center;overflow:hidden;background:#000;color:#fff;transition:opacity .35s ease;pointer-events:none}
+      #opening-cue::before{content:"";position:absolute;inset:0;background:radial-gradient(closest-side,rgba(255,255,255,.08),transparent 60%);animation:opening-glow 1.2s ease-out both}
+      #opening-cue.is-exiting{opacity:0}
+      .opening-cue__copy{text-align:center;font:400 .875rem/1.25 ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;text-transform:uppercase;letter-spacing:.35em}
+      .opening-cue__standby,.opening-cue__go{opacity:0;animation:opening-standby 1.6s ease-in-out both}
+      .opening-cue__go{margin-top:.5rem;animation-name:opening-go}
+      @keyframes opening-glow{from{opacity:.35;transform:scale(.9)}to{opacity:0;transform:scale(1.5)}}
+      @keyframes opening-standby{0%{opacity:0}10%,85%{opacity:.8}95%,100%{opacity:0}}
+      @keyframes opening-go{0%,20%{opacity:0}55%,90%{opacity:1}98%,100%{opacity:0}}
+      @media (prefers-reduced-motion:reduce){#opening-cue::before{animation:none}.opening-cue__standby{animation:none;opacity:.8}.opening-cue__go{animation:none;opacity:1}}
+    </style>
+    <script>window.__hkOpeningCueStarted = performance.now();</script>
+    <div id="opening-cue" role="status" aria-label="The website is opening">
+      <div class="opening-cue__copy" aria-hidden="true">
+        <div class="opening-cue__standby">Standby LX 1.</div>
+        <div class="opening-cue__go">LX 1&hellip; Go.</div>
+      </div>
+    </div>
     <div id="root"></div>
     <!-- IMPORTANT: no /henrykacik/ here -->
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>
-

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1702,9 +1702,11 @@ export default function HenryKacikSite() {
   // crossfades immediately behind the cue so neither mode can expose a blank page.
   const [lxMode, setLxMode] = useState(true);
   const cueRef = useRef(2);
-  const [showCue, setShowCue] = useState(true);
+  // The first cue lives in index.html so it appears before this JavaScript
+  // bundle loads. React owns subsequent route cues only.
+  const [showCue, setShowCue] = useState(false);
   const [cueNumber, setCueNumber] = useState(1);
-  const [openingCue, setOpeningCue] = useState(true);
+  const [openingCue, setOpeningCue] = useState(false);
   const [renderRoute, setRenderRoute] = useState(currentRoute);
   const previousRouteRef = useRef(currentRoute);
   const hasEnteredRef = useRef(false);
@@ -1712,11 +1714,16 @@ export default function HenryKacikSite() {
   useEffect(() => { injectFonts(); }, []);
   useEffect(() => {
     hasEnteredRef.current = true;
-    const timer = window.setTimeout(() => {
-      setShowCue(false);
-      setOpeningCue(false);
-    }, 1750);
-    return () => window.clearTimeout(timer);
+    const openingCue = document.getElementById('opening-cue');
+    if (!openingCue) return;
+    const startedAt = window.__hkOpeningCueStarted ?? performance.now();
+    const remaining = Math.max(0, 1750 - (performance.now() - startedAt));
+    const exitTimer = window.setTimeout(() => openingCue.classList.add('is-exiting'), remaining);
+    const removeTimer = window.setTimeout(() => openingCue.remove(), remaining + 400);
+    return () => {
+      window.clearTimeout(exitTimer);
+      window.clearTimeout(removeTimer);
+    };
   }, []);
   // Inject project schema once on mount
   useEffect(() => { try { injectProjectSchema(); } catch {} }, []);


### PR DESCRIPTION
### Motivation

- Ensure the theatrical "LX 1" entrance is visible immediately when the page first loads instead of waiting for React, fonts, or the hero image to arrive. 
- Prevent GitHub Actions from emitting a Node.js 20 deprecation annotation by avoiding the action that delegates to Node 20 runtime. 
- Keep React in charge of subsequent route-change cues while avoiding duplication of the initial entrance.

### Description

- Render a server-delivered opening cue in `index.html` (HTML + inline CSS + a small timestamp script) so the entrance animation and accessibility status begin before the app bundle loads. 
- Wire React to detect and gracefully remove that server-rendered cue by reading `window.__hkOpeningCueStarted`, computing the remaining display time, fading the cue, and removing it from the DOM once finished (`src/App.jsx` changes). 
- Stop React from assuming it must show the first cue by default (`showCue`/`openingCue` default to `false`) so there is no duplicate cue animation. 
- Replace the Pages upload step in `.github/workflows/deploy.yml` with an explicit packaging step plus `actions/upload-artifact@v5` uploading a `github-pages.tar` artifact to avoid the `actions/upload-pages-artifact@v4` behavior that produced the Node 20 annotation.

### Testing

- Ran `npm install` and it completed successfully. 
- Ran `npm run build` (Vite) and the site built successfully into `dist` (build completed; note a chunk-size warning was emitted). 
- Ran `git diff --check` and `git status --short` to validate the workspace; both checks passed and show the three modified files (`index.html`, `src/App.jsx`, `.github/workflows/deploy.yml`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8247e8aec8832bae984daf43916691)