### PR TITLE
Improve gallery load performance and make photos fill their tiles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1200,7 +1200,8 @@ const MosaicGallery = ({ project, onSelect }) => {
               y={y}
               width={cellWidth}
               height={cellHeight}
-              preserveAspectRatio="xMidYMid meet"
+              preserveAspectRatio="xMidYMid slice"
+              fetchPriority={index < columns ? 'high' : 'low'}
               clipPath={`url(#mosaic-${project.id}-${index})`}
               onLoad={() => setLoadedImages(previous => {
                 const next = new Set(previous);
@@ -1727,7 +1728,9 @@ export default function HenryKacikSite() {
   }, []);
   // Inject project schema once on mount
   useEffect(() => { try { injectProjectSchema(); } catch {} }, []);
-  // Tamer image preloading: respect Data Saver, only hero + first 2 per project
+  // Warm the small, immediately useful images only. Gallery photographs can be
+  // very large, so downloading several from every project while the browser is
+  // idle competes with the gallery the visitor actually chooses to open.
   useEffect(() => {
     const ric = (typeof window !== 'undefined' && window.requestIdleCallback)
       ? window.requestIdleCallback
@@ -1743,10 +1746,7 @@ export default function HenryKacikSite() {
         img.src = u;
       };
       preload(ABOUT.photo, true);
-      PROJECTS.forEach((p, idx) => {
-        const imgs = [p.hero, ...(p.photos || []).slice(0, 2)];
-        imgs.forEach(u => preload(u, idx === 0)); // only first project eager
-      });
+      preload(PROJECTS[0]?.hero, true);
     });
   }, []);
   const go = useCallback((r) => {


### PR DESCRIPTION
### Motivation
- The gallery opened slowly because many large photos were being preloaded for every project, competing with the images needed immediately when a visitor opens a gallery.  
- Photographs displayed letterboxed/dark areas due to the SVG `<image>` using `meet` scaling, so images needed to consistently fill their mosaic cells.

### Description
- Set SVG image scaling to `preserveAspectRatio="xMidYMid slice"` so photos fill mosaic cells without dark letterboxing.  
- Added `fetchPriority={index < columns ? 'high' : 'low'}` to the mosaic `<image>` elements to prioritize the first visible row of images.  
- Reduced background preloading to only warm the small headshot and the first project hero by changing the idle preload logic to `preload(ABOUT.photo, true)` and `preload(PROJECTS[0]?.hero, true)` instead of preloading multiple large photos per project.  
- All edits were made in `src/App.jsx` (gallery/mosaic rendering and top-level preloading logic). 

### Testing
- Ran `npm run build`, which completed successfully (bundles produced; build reported chunk-size warnings but exited with success).  
- Ran `git diff --check` which reported no whitespace or diff-check issues.  
- Verified the changed code compiles in the production build (no runtime build errors during `vite build`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a824a4a0988832b964d00236799e3c7)