### PR TITLE
Make gallery highlights more dramatic

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1103,8 +1103,11 @@ const MosaicGallery = ({ project, onSelect }) => {
     const heroRow = Math.floor(heroIndex / columns);
     const heroColumn = heroIndex % columns;
     const hasHero = heroIndex !== null;
-    const columnWeights = Array.from({ length: columns }, (_, column) => hasHero && column === heroColumn ? 1.85 : 1);
-    const rowWeights = Array.from({ length: rows }, (_, row) => hasHero && row === heroRow ? 1.7 : 1);
+    // Let the active pane take over the wall rather than merely nudging its
+    // neighbours. The independent row/column expansion keeps the silhouette
+    // fluid while making the highlighted image the clear largest pane.
+    const columnWeights = Array.from({ length: columns }, (_, column) => hasHero && column === heroColumn ? 3.4 : 1);
+    const rowWeights = Array.from({ length: rows }, (_, row) => hasHero && row === heroRow ? 3 : 1);
     const columnTotal = columnWeights.reduce((sum, value) => sum + value, 0);
     const rowTotal = rowWeights.reduce((sum, value) => sum + value, 0);
     const xLines = columnWeights.reduce((lines, value) => [...lines, lines.at(-1) + width * value / columnTotal], [0]);
@@ -1200,7 +1203,7 @@ const MosaicGallery = ({ project, onSelect }) => {
               y={y}
               width={cellWidth}
               height={cellHeight}
-              preserveAspectRatio="xMidYMid slice"
+              preserveAspectRatio="xMidYMid meet"
               fetchPriority={index < columns ? 'high' : 'low'}
               clipPath={`url(#mosaic-${project.id}-${index})`}
               onLoad={() => setLoadedImages(previous => {

--- a/src/index.css
+++ b/src/index.css
@@ -51,10 +51,10 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 .mosaic-piece image { opacity: 0; filter: saturate(.72) brightness(.62); transition: opacity 650ms ease, filter 900ms cubic-bezier(.16,1,.3,1); }
 .mosaic-piece image.is-loaded { opacity: 1; }
 .mosaic-piece__edge { fill: transparent; stroke: #090909; stroke-width: 10; vector-effect: non-scaling-stroke; transition: stroke 650ms cubic-bezier(.16,1,.3,1), stroke-width 650ms cubic-bezier(.16,1,.3,1); }
-.mosaic-gallery:has(.mosaic-piece--hero) .mosaic-piece:not(.mosaic-piece--hero) { opacity: .68; }
-.mosaic-gallery:has(.mosaic-piece--hero) .mosaic-piece:not(.mosaic-piece--hero) image { filter: saturate(.7) brightness(.66); }
-.mosaic-piece--hero image { filter: saturate(1.04) brightness(1.04); }
-.mosaic-piece--hero .mosaic-piece__edge { stroke: #090909; stroke-width: 10; }
+.mosaic-gallery:has(.mosaic-piece--hero) .mosaic-piece:not(.mosaic-piece--hero) { opacity: .42; }
+.mosaic-gallery:has(.mosaic-piece--hero) .mosaic-piece:not(.mosaic-piece--hero) image { filter: saturate(.55) brightness(.48); }
+.mosaic-piece--hero image { filter: saturate(1.08) brightness(1.08); }
+.mosaic-piece--hero .mosaic-piece__edge { stroke: rgba(255,255,255,.82); stroke-width: 14; }
 
 .stained-gallery__grid {
   display: grid;


### PR DESCRIPTION
### Motivation
- Highlighted gallery panes should clearly become the dominant pane in the mosaic so a hovered or keyboard-focused image reads as the largest element on the wall.
- The highlighted pane should preserve as much of the original photo as possible inside the dynamic polygonal shape rather than aggressively cropping it.
- Visual contrast should be stronger so the active image pops: surrounding panes dim more and the active border becomes brighter and thicker.

### Description
- Increase the hero pane expansion by raising the column and row weight multipliers from `1.85 / 1.7` to `3.4 / 3` in `src/App.jsx` so the active pane grows to be the largest element in the layout.
- Change image fitting inside SVG mosaic cells from `preserveAspectRatio="xMidYMid slice"` to `preserveAspectRatio="xMidYMid meet"` in `src/App.jsx` to show more of the original photo inside the dynamic shape.
- Make non-active panes substantially darker and less saturated, and boost the active image's saturation/brightness plus the active border’s color and stroke width in `src/index.css` to increase visual emphasis.
- Files changed: `src/App.jsx`, `src/index.css`.

### Testing
- Ran `npm run build`, which completed successfully and produced the production build artifacts. (success)
- Ran `git diff --check` to validate whitespace and diff issues, which completed with no reported problems. (success)
- Verified repository state with `git status --short`, showing the changes staged/committed. (success)
- Attempted to invoke the local `make_pr` helper via the environment MCP tooling to record PR metadata, but that helper could not be executed due to a network/proxy failure when fetching a Python dependency from PyPI. (failure)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82551614a0832b81c21d1e399297b1)