### PR TITLE
Restore standard portfolio gallery layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1087,138 +1087,30 @@ const ProjectCard = ({ project }) => {
   );
 };
 
-const mosaicColumns = (count) => {
-  if (count % 5 === 0) return 5;
-  if (count % 4 === 0) return 4;
-  if (count % 3 === 0) return 3;
-  return Math.min(count, 5);
-};
-
-const MosaicGallery = ({ project, onSelect }) => {
-  const columns = mosaicColumns(project.photos.length);
-  const rows = Math.ceil(project.photos.length / columns);
-  const width = 1200;
-  const height = 760;
-  const layoutFor = useCallback((heroIndex) => {
-    const heroRow = Math.floor(heroIndex / columns);
-    const heroColumn = heroIndex % columns;
-    const hasHero = heroIndex !== null;
-    // Let the active pane take over the wall rather than merely nudging its
-    // neighbours. The independent row/column expansion keeps the silhouette
-    // fluid while making the highlighted image the clear largest pane.
-    const columnWeights = Array.from({ length: columns }, (_, column) => hasHero && column === heroColumn ? 3.4 : 1);
-    const rowWeights = Array.from({ length: rows }, (_, row) => hasHero && row === heroRow ? 3 : 1);
-    const columnTotal = columnWeights.reduce((sum, value) => sum + value, 0);
-    const rowTotal = rowWeights.reduce((sum, value) => sum + value, 0);
-    const xLines = columnWeights.reduce((lines, value) => [...lines, lines.at(-1) + width * value / columnTotal], [0]);
-    const yLines = rowWeights.reduce((lines, value) => [...lines, lines.at(-1) + height * value / rowTotal], [0]);
-    return Array.from({ length: rows + 1 }, (_, row) =>
-      Array.from({ length: columns + 1 }, (_, column) => {
-        const edgeX = column === 0 || column === columns;
-        const edgeY = row === 0 || row === rows;
-        const xJitter = edgeX ? 0 : (((row * 47 + column * 31) % 97) - 48) * 1.55;
-        const yJitter = edgeY ? 0 : (((row * 29 + column * 53) % 83) - 41) * 1.65;
-        return [xLines[column] + xJitter, yLines[row] + yJitter];
-      })
-    );
-  }, [columns, rows]);
-  const [heroIndex, setHeroIndex] = useState(null);
-  const [loadedImages, setLoadedImages] = useState(() => new Set());
-  const [nodes, setNodes] = useState(() => layoutFor(null));
-  const nodesRef = useRef(nodes);
-
-  useEffect(() => {
-    const from = nodesRef.current;
-    const target = layoutFor(heroIndex);
-    const started = performance.now();
-    let frame = 0;
-    const animate = (now) => {
-      const progress = Math.min(1, (now - started) / 950);
-      const eased = 1 - Math.pow(1 - progress, 3);
-      const next = from.map((line, row) => line.map((point, column) => [
-        point[0] + (target[row][column][0] - point[0]) * eased,
-        point[1] + (target[row][column][1] - point[1]) * eased,
-      ]));
-      nodesRef.current = next;
-      setNodes(next);
-      if (progress < 1) frame = requestAnimationFrame(animate);
-    };
-    frame = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(frame);
-  }, [heroIndex, layoutFor]);
-
-  const points = useMemo(() => {
-    return project.photos.map((_, index) => {
-      const row = Math.floor(index / columns);
-      const column = index % columns;
-      return [nodes[row][column], nodes[row][column + 1], nodes[row + 1][column + 1], nodes[row + 1][column]];
-    });
-  }, [columns, project.photos, nodes]);
-
-  return (
-    <svg
-      className="mosaic-gallery"
-      viewBox={`0 0 ${width} ${height}`}
-      preserveAspectRatio="xMidYMid meet"
-      aria-label={`${project.title} photo mosaic`}
-      data-hero-index={heroIndex ?? ''}
-      onPointerLeave={() => setHeroIndex(null)}
-    >
-      <defs>
-        {points.map((polygon, index) => (
-          <clipPath id={`mosaic-${project.id}-${index}`} key={index}>
-            <polygon points={polygon.map(point => point.join(',')).join(' ')} />
-          </clipPath>
-        ))}
-      </defs>
-      {project.photos.map((src, index) => {
-        const polygon = points[index];
-        const xs = polygon.map(([x]) => x);
-        const ys = polygon.map(([, y]) => y);
-        const x = Math.min(...xs);
-        const y = Math.min(...ys);
-        const cellWidth = Math.max(...xs) - x;
-        const cellHeight = Math.max(...ys) - y;
-        return (
-          <g
-            className={`mosaic-piece${heroIndex === index ? ' mosaic-piece--hero' : ''}`}
-            key={src}
-            role="button"
-            tabIndex="0"
-            aria-label={`View image ${index + 1} from ${project.title}`}
-            onPointerEnter={() => setHeroIndex(index)}
-            onFocus={() => setHeroIndex(index)}
-            onClick={() => onSelect(index)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
-                onSelect(index);
-              }
-            }}
-          >
-            <image
-              className={loadedImages.has(index) ? 'is-loaded' : ''}
-              href={src}
-              x={x}
-              y={y}
-              width={cellWidth}
-              height={cellHeight}
-              preserveAspectRatio="xMidYMid meet"
-              fetchPriority={index < columns ? 'high' : 'low'}
-              clipPath={`url(#mosaic-${project.id}-${index})`}
-              onLoad={() => setLoadedImages(previous => {
-                const next = new Set(previous);
-                next.add(index);
-                return next;
-              })}
-            />
-            <polygon className="mosaic-piece__edge" points={polygon.map(point => point.join(',')).join(' ')} />
-          </g>
-        );
-      })}
-    </svg>
-  );
-};
+const GalleryGrid = ({ project, onSelect }) => (
+  <div className="gallery-grid" aria-label={`${project.title} photographs`}>
+    {project.photos.map((src, index) => (
+      <button
+        type="button"
+        className="gallery-thumbnail group"
+        key={src}
+        aria-label={`View image ${index + 1} of ${project.photos.length} from ${project.title}`}
+        onClick={() => onSelect(index)}
+      >
+        <img
+          src={src}
+          alt={project.captions?.[index] || `${project.title}, photograph ${index + 1}`}
+          loading={index < 6 ? 'eager' : 'lazy'}
+          decoding="async"
+          fetchpriority={index < 3 ? 'high' : 'low'}
+        />
+        <span className="gallery-thumbnail__index" aria-hidden="true">
+          {String(index + 1).padStart(2, '0')}
+        </span>
+      </button>
+    ))}
+  </div>
+);
 
 const Portfolio = () => {
   const [active, setActive] = useState(null);
@@ -1377,9 +1269,9 @@ const Portfolio = () => {
                   initial={{opacity:0, y:12}}
                   animate={{opacity:1, y:0}}
                   transition={{duration:0.45}}
-                  className="stained-gallery"
+                  className="gallery-overview"
                 >
-                  <MosaicGallery
+                  <GalleryGrid
                     project={active}
                     onSelect={(photoIdx) => {
                       setIdx(photoIdx);

--- a/src/index.css
+++ b/src/index.css
@@ -30,153 +30,59 @@ img, video, canvas {
 img[data-fit="cover"]   { width: 100%; height: 100%; object-fit: cover;  object-position: center; }
 img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object-position: center; }
 
-/* --- portfolio gallery: an architectural wall of illuminated panes --- */
-.stained-gallery {
-  position: relative;
-  isolation: isolate;
-  background: #070707;
-  border: 1px solid rgba(255,255,255,.18);
-  border-radius: 0;
-  box-shadow: 0 28px 80px rgba(0,0,0,.55), inset 0 0 0 1px rgba(255,255,255,.05);
-  overflow: hidden;
-  width: 100%;
-  aspect-ratio: 30 / 19;
-  height: auto;
-  max-height: calc(100svh - 10.75rem);
-}
-
-.gallery-dialog-shell { width: min(100%, 112rem); }
-.mosaic-gallery { display: block; width: 100%; height: 100%; background: #070707; touch-action: pan-y; }
-.mosaic-piece { cursor: pointer; outline: none; transform-box: fill-box; transform-origin: center; transition: transform 700ms cubic-bezier(.16,1,.3,1), opacity 500ms ease; }
-.mosaic-piece image { opacity: 0; filter: saturate(.72) brightness(.62); transition: opacity 650ms ease, filter 900ms cubic-bezier(.16,1,.3,1); }
-.mosaic-piece image.is-loaded { opacity: 1; }
-.mosaic-piece__edge { fill: transparent; stroke: #090909; stroke-width: 10; vector-effect: non-scaling-stroke; transition: stroke 650ms cubic-bezier(.16,1,.3,1), stroke-width 650ms cubic-bezier(.16,1,.3,1); }
-.mosaic-gallery:has(.mosaic-piece--hero) .mosaic-piece:not(.mosaic-piece--hero) { opacity: .42; }
-.mosaic-gallery:has(.mosaic-piece--hero) .mosaic-piece:not(.mosaic-piece--hero) image { filter: saturate(.55) brightness(.48); }
-.mosaic-piece--hero image { filter: saturate(1.08) brightness(1.08); }
-.mosaic-piece--hero .mosaic-piece__edge { stroke: rgba(255,255,255,.82); stroke-width: 14; }
-
-.stained-gallery__grid {
+/* --- portfolio gallery: a straightforward, image-first contact sheet --- */
+.gallery-dialog-shell { width: min(100%, 96rem); }
+.gallery-overview { padding-bottom: 2rem; }
+.gallery-grid {
   display: grid;
-  grid-template-columns: repeat(12, minmax(0, 1fr));
-  grid-auto-flow: dense;
-  grid-auto-rows: clamp(3.2rem, 5.5vw, 5.2rem);
-  gap: clamp(0.35rem, 0.65vw, 0.6rem);
-  padding: clamp(0.15rem, 0.3vw, 0.25rem);
-  background: #111;
-  border-radius: .75rem;
-  overflow: hidden;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: clamp(.75rem, 1.5vw, 1.5rem);
 }
-
-.stained-pane {
+.gallery-thumbnail {
   position: relative;
   display: block;
-  width: 100%;
-  grid-column: span 3;
-  grid-row: span 3;
-  min-width: 0;
+  aspect-ratio: 3 / 2;
   overflow: hidden;
-  color: white;
-  background: #171717;
-  border: 0;
-  border-radius: .25rem;
-  box-shadow: inset 0 0 0 1px rgba(255,255,255,.1);
-  transform: translateZ(0);
-  transition: filter 700ms cubic-bezier(.16,1,.3,1), opacity 700ms cubic-bezier(.16,1,.3,1), transform 700ms cubic-bezier(.16,1,.3,1), box-shadow 700ms cubic-bezier(.16,1,.3,1);
+  border: 1px solid rgba(255,255,255,.14);
+  background: #111;
 }
-.stained-pane:nth-child(8n + 1), .stained-pane:nth-child(8n + 6) { grid-column: span 5; grid-row: span 4; }
-.stained-pane:nth-child(8n + 2), .stained-pane:nth-child(8n + 7) { grid-column: span 4; grid-row: span 4; }
-.stained-pane:nth-child(8n + 3) { grid-column: span 3; grid-row: span 4; }
-.stained-pane:nth-child(8n + 4) { grid-column: span 4; grid-row: span 3; }
-.stained-pane:nth-child(8n + 5) { grid-column: span 3; grid-row: span 3; }
-.stained-pane:nth-child(8n) { grid-column: span 5; grid-row: span 3; }
-
-.stained-pane img {
-  display: block;
+.gallery-thumbnail img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  filter: saturate(.94) contrast(1.04) brightness(.88);
-  transform: scale(1.01);
-  transition: filter 900ms cubic-bezier(.16,1,.3,1), transform 1100ms cubic-bezier(.16,1,.3,1);
+  filter: brightness(.9);
+  transition: filter 450ms ease, transform 650ms cubic-bezier(.16,1,.3,1);
 }
-
-.stained-pane::after {
-  content: '';
+.gallery-thumbnail__index {
   position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background: linear-gradient(180deg, transparent 55%, rgba(0,0,0,.48));
-  opacity: .65;
-  transition: opacity 500ms ease;
+  right: .65rem;
+  bottom: .55rem;
+  padding: .2rem .4rem;
+  background: rgba(0,0,0,.7);
+  color: rgba(255,255,255,.9);
+  font-size: .65rem;
+  letter-spacing: .12em;
 }
-
-.stained-pane__number {
-  position: absolute;
-  z-index: 2;
-  right: .8rem;
-  bottom: .65rem;
-  font-size: .62rem;
-  letter-spacing: .16em;
-  color: rgba(255,255,255,.78);
-  opacity: 0;
-  transform: translateY(4px);
-  transition: opacity 400ms ease, transform 500ms cubic-bezier(.16,1,.3,1);
-}
-
-.stained-gallery__grid:has(.stained-pane:is(:hover, :focus-visible)) .stained-pane:not(:hover):not(:focus-visible) {
-  filter: brightness(.62) saturate(.7);
-  opacity: .8;
-}
-
-.stained-pane:hover,
-.stained-pane:focus-visible {
-  z-index: 3;
-  outline: none;
-  box-shadow: 0 18px 35px rgba(0,0,0,.38), inset 0 0 0 1px rgba(255,255,255,.32);
-  transform: scale(1.012);
-}
-
-.stained-pane:hover img,
-.stained-pane:focus-visible img {
-  filter: saturate(1.03) contrast(1.05) brightness(1);
-  transform: scale(1.045);
-}
-.stained-pane:hover::after, .stained-pane:focus-visible::after { opacity: .35; }
-.stained-pane:hover .stained-pane__number, .stained-pane:focus-visible .stained-pane__number { opacity: 1; transform: translateY(0); }
+.gallery-thumbnail:hover img,
+.gallery-thumbnail:focus-visible img { filter: brightness(1); transform: scale(1.025); }
+.gallery-thumbnail:focus-visible { outline: 2px solid white; outline-offset: 3px; }
 
 /* Keep off-screen portfolio sections out of the initial layout/paint budget. */
 .portfolio-project { content-visibility: auto; contain-intrinsic-size: auto 760px; }
 
 @media (max-width: 900px) {
-  .stained-gallery__grid { grid-template-columns: repeat(8, minmax(0, 1fr)); grid-auto-rows: clamp(3.5rem, 8vw, 5rem); }
-  .stained-pane:nth-child(n) { grid-column: span 4; grid-row: span 3; }
-  .stained-pane:nth-child(5n + 1), .stained-pane:nth-child(5n + 4) { grid-column: span 5; grid-row: span 4; }
-  .stained-pane:nth-child(5n + 2), .stained-pane:nth-child(5n + 5) { grid-column: span 3; grid-row: span 4; }
+  .gallery-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 
 @media (max-width: 640px) {
-  .stained-gallery { border-radius: .25rem; }
-  .stained-gallery { aspect-ratio: 4 / 5; max-height: calc(100svh - 13.5rem); }
-  .stained-gallery__grid { grid-template-columns: repeat(2, minmax(0, 1fr)); grid-auto-rows: 5rem; gap: .4rem; padding: 0; }
-  .stained-pane:nth-child(n) { grid-column: span 1; grid-row: span 2; }
-  .stained-pane:nth-child(4n + 1) { grid-column: 1 / -1; grid-row: span 3; }
-  .stained-gallery__grid:has(.stained-pane:is(:hover, :focus-visible)) .stained-pane:not(:hover):not(:focus-visible) { filter: none; opacity: 1; }
-  .stained-pane__number { opacity: .8; transform: none; }
-  .mosaic-piece:hover, .mosaic-piece:focus-visible { transform: scale(1.045); }
+  .gallery-grid { grid-template-columns: 1fr; gap: .75rem; }
 }
 
 @media (prefers-reduced-motion: reduce) {
   html, body, #root { scroll-behavior: auto; }
   .page-transition { will-change: auto; }
   img { transition: none; }
-  .mosaic-piece image,
-  .mosaic-piece,
-  .mosaic-piece__edge,
-  .stained-pane,
-  .stained-pane img { transition: none; }
-  .stained-pane:hover,
-  .stained-pane:focus-visible { transform: none; }
+  .gallery-thumbnail img { transition: none; }
 }
 
 /* --- shared editorial language across primary pages --- */


### PR DESCRIPTION
### Motivation

- The experimental animated mosaic gallery proved to be less suitable for a conventional portfolio presentation, so the gallery UX is being simplified to a more standard, image-first layout.
- The intent is to improve clarity, predictability, and accessibility while preserving the existing lightbox and exchangeable full-photo experience.

### Description

- Replaced the animated/mosaic gallery components with a simple responsive thumbnail grid component `GalleryGrid` in `src/App.jsx` that renders clickable thumbnails and indices and forwards selection into the existing lightbox flow.
- Removed the previous `MosaicGallery` layout and associated layout/animation code and switched project dialogs to render `<GalleryGrid />` while keeping selection handlers, analytics `track` calls, captions, and lightbox navigation intact.
- Simplified and added CSS in `src/index.css` to implement a three/two/one-column contact-sheet style grid (`.gallery-grid`, `.gallery-thumbnail`, `.gallery-overview`) with hover, focus styles and `prefers-reduced-motion` support.
- Kept all lightbox functionality and controls (keyboard navigation, captions, share/copy link, and previous/next behavior) unchanged so the full-image experience remains intact.

### Testing

- Ran `npm run build` (Vite) to build a production bundle, which completed successfully with the standard chunk-size warnings. 
- Ran `git diff --check` (no whitespace/formatting errors) and inspected local changes to ensure the mosaic code was fully replaced and new grid styles applied. 
- Attempted `npx playwright install chromium` for an optional visual smoke test, but the environment failed to download Playwright from the npm registry (HTTP 403) due to registry/policy restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a825f4bc874832baad7c8088323aa9f)