### PR TITLE
Make portfolio galleries scrollable and photo-forward

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1212,7 +1212,7 @@ const Portfolio = () => {
             initial={{opacity:0}}
             animate={{opacity:1}}
             exit={{opacity:0}}
-            className="fixed inset-0 z-50 bg-black/95 p-2 sm:p-4 overflow-y-auto flex justify-center"
+            className="gallery-dialog fixed inset-0 z-50 bg-black/95 p-2 sm:p-4"
             role="dialog"
             aria-modal="true"
             aria-label={`${active.title} gallery`}

--- a/src/index.css
+++ b/src/index.css
@@ -30,13 +30,23 @@ img, video, canvas {
 img[data-fit="cover"]   { width: 100%; height: 100%; object-fit: cover;  object-position: center; }
 img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object-position: center; }
 
-/* --- portfolio gallery: a straightforward, image-first contact sheet --- */
-.gallery-dialog-shell { width: min(100%, 96rem); }
-.gallery-overview { padding-bottom: 2rem; }
+/* --- portfolio gallery: a scrollable, image-first contact sheet --- */
+.gallery-dialog {
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+  -webkit-overflow-scrolling: touch;
+}
+.gallery-dialog-shell { width: min(100%, 96rem); min-height: 100%; }
+.gallery-overview { padding-bottom: clamp(3rem, 8vh, 7rem); }
 .gallery-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: clamp(.75rem, 1.5vw, 1.5rem);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: clamp(1rem, 2vw, 2rem);
 }
 .gallery-thumbnail {
   position: relative;
@@ -70,12 +80,8 @@ img[data-fit="contain"] { width: 100%; height: 100%; object-fit: contain; object
 /* Keep off-screen portfolio sections out of the initial layout/paint budget. */
 .portfolio-project { content-visibility: auto; contain-intrinsic-size: auto 760px; }
 
-@media (max-width: 900px) {
-  .gallery-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-}
-
-@media (max-width: 640px) {
-  .gallery-grid { grid-template-columns: 1fr; gap: .75rem; }
+@media (max-width: 720px) {
+  .gallery-grid { grid-template-columns: 1fr; gap: 1rem; }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
### Motivation
- The gallery modal previously prevented scrolling through all thumbnails, making some photos inaccessible on smaller viewports or when thumbnails were enlarged. 
- Photos on the gallery overview needed to be more prominent, even if that requires additional vertical scrolling.

### Description
- Updated the gallery dialog markup in `src/App.jsx` to use a dedicated `gallery-dialog` wrapper so the gallery can be an independently scrollable, full-viewport surface. 
- Added `.gallery-dialog` styles in `src/index.css` to enable vertical scrolling, momentum touch scrolling, `overscroll-behavior`, `touch-action`, and a full-viewport height (`100dvh`) for reliable behavior on mobile. 
- Enlarged the overview thumbnails by switching the desktop grid from three columns to two (`.gallery-grid`) and increased spacing, while keeping a single-column layout below `720px` for mobile. 
- Ensured the dialog shell has `min-height: 100%` and added bottom padding via `.gallery-overview` so larger images have visual breathing room.

### Testing
- Ran `npm run build` and the production build completed successfully. 
- Ran `git diff --check` and no issues were reported. 
- Verified changes were staged and committed (`git status --short` and `git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a828e74e9d0832bbef00d37307460cf)